### PR TITLE
Fix plain text log messages with double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Tableau Log Viewer is cross-platform tool with a simple interface that has a single purpose of making it easy to quickly glance over Tableau log files.
 
-Features
+![TLV Screenshot](https://cloud.githubusercontent.com/assets/1087437/19377630/b1ca0d56-919c-11e6-9c01-200697c37194.png "TLV running on Windows 10")
+
+Overview
 ---------------
 * Tableau log file representation in easy to read columnar format
 * Advanced event search and highlighting
@@ -10,8 +12,14 @@ Features
 * Live capture: events appear as they happen
 * Supported on Windows and Mac (and can be built on Linux)
 
-How do I get started with Tableau Log Viewer?
-Simply launch the application and drag'n'drop Tableau's log file. Both Tableau Desktop and [most] Tableau Server log files are supported. More detailed information can be found on [wiki](https://github.com/tableau/tableau-log-viewer/wiki)
+How do I use Tableau Log Viewer?
+---------------
+Simply launch the application and drag'n'drop Tableau's log file. Both Tableau Desktop and [most] Tableau Server log files are supported.
+Take a look at our [wiki](https://github.com/tableau/tableau-log-viewer/wiki) to get more details on the features and usage of TLV.
+
+How do I build Tableau Log Viewer?
+---------------
+See [INSTALL.md](INSTALL.md)
 
 Is Tableau Log Viewer supported?
 ---------------

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -39,12 +39,12 @@ void LogTab::InitTreeView(const EventListPtr events)
 
     m_bar->ShowMessage(QString("%1 events loaded").arg(QString::number(m_treeModel->rowCount())), 3000);
 
-    bool isPlainText = (events->size() > 0 && events->at(0)["k"].toString().isEmpty());
+    bool hasNoKey = (events->size() > 0 && events->at(0)["k"].toString().isEmpty());
 
     SetColumn(COL::ID, 80, false);
     SetColumn(COL::File, 110, true);
-    SetColumn(COL::Time, 190, isPlainText);
-    SetColumn(COL::Elapsed, 50, isPlainText);
+    SetColumn(COL::Time, 190, hasNoKey);
+    SetColumn(COL::Elapsed, 50, hasNoKey);
     SetColumn(COL::PID, 30, true);
     SetColumn(COL::TID, 50, true);
     SetColumn(COL::Severity, 50, true);
@@ -52,7 +52,7 @@ void LogTab::InitTreeView(const EventListPtr events)
     SetColumn(COL::Session, 30, true);
     SetColumn(COL::Site, 180, true);
     SetColumn(COL::User, 30, true);
-    SetColumn(COL::Key, 120, isPlainText);
+    SetColumn(COL::Key, 120, hasNoKey);
 
     ui->treeView->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->treeView->header()->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -39,10 +39,12 @@ void LogTab::InitTreeView(const EventListPtr events)
 
     m_bar->ShowMessage(QString("%1 events loaded").arg(QString::number(m_treeModel->rowCount())), 3000);
 
+    bool isPlainText = (events->size() > 0 && events->at(0)["k"].toString().isEmpty());
+
     SetColumn(COL::ID, 80, false);
     SetColumn(COL::File, 110, true);
-    SetColumn(COL::Time, 190, false);
-    SetColumn(COL::Elapsed, 50, false);
+    SetColumn(COL::Time, 190, isPlainText);
+    SetColumn(COL::Elapsed, 50, isPlainText);
     SetColumn(COL::PID, 30, true);
     SetColumn(COL::TID, 50, true);
     SetColumn(COL::Severity, 50, true);
@@ -50,7 +52,7 @@ void LogTab::InitTreeView(const EventListPtr events)
     SetColumn(COL::Session, 30, true);
     SetColumn(COL::Site, 180, true);
     SetColumn(COL::User, 30, true);
-    SetColumn(COL::Key, 120, false);
+    SetColumn(COL::Key, 120, isPlainText);
 
     ui->treeView->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->treeView->header()->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -491,7 +493,7 @@ void LogTab::ShowDetails(const QModelIndex& idx, ValueDlg& valueDlg)
     valueDlg.m_key = idx_key.data().toString();
 
     valueDlg.setWindowTitle(QString("ID: %1 - Key: %2").arg(valueDlg.m_id, valueDlg.m_key));
-    bool syntaxHighlight = (valueDlg.m_key != "msg");
+    bool syntaxHighlight = (!valueDlg.m_key.isEmpty() && valueDlg.m_key != "msg");
     valueDlg.SetText(value, syntaxHighlight);
     valueDlg.SetQuery(QString(""));
 
@@ -836,7 +838,7 @@ void LogTab::InitHeaderMenu()
         QAction *action = new QAction(hdata.toString(), m_headerMenu);
         action->setCheckable(true);
         // Make some columns 'unhidable'
-        if (i == COL::ID || i == COL::Key || i == COL::Value)
+        if (i == COL::ID || i == COL::Value)
         {
             action->setEnabled(false);
         }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -8,7 +8,6 @@
 
 void Options::ReadSettings()
 {
-    QSysInfo systemInfo;
     QString iniPath = PathHelper::GetConfigIniPath();
     QSettings settings(iniPath, QSettings::IniFormat);
     settings.beginGroup("Options");
@@ -18,7 +17,7 @@ void Options::ReadSettings()
     m_skippedState = settings.value("skippedState", QBitArray(m_skippedText.length(), true)).toBitArray();
     m_visualizationServiceEnable = settings.value("visualizationServiceEnable", false).toBool();
     m_visualizationServiceURL = settings.value("visualizationServiceURL", QString("")).toString();
-    auto defaultDiffToolPath = systemInfo.productType() == "windows" ? QString("C:/Program Files (x86)/Beyond Compare 4/BCompare.exe") : QString("/usr/local/bin/bcomp");
+    auto defaultDiffToolPath = QSysInfo::productType() == "windows" ? QString("C:/Program Files (x86)/Beyond Compare 4/BCompare.exe") : QString("/usr/local/bin/bcomp");
     m_diffToolPath = settings.value("diffToolPath", defaultDiffToolPath).toString();
     m_futureTabsUnderLive = settings.value("enableLiveCapture").toBool();
     m_defaultFilterName = settings.value("defaultHighlightFilter", "None").toString();

--- a/src/processevent.cpp
+++ b/src/processevent.cpp
@@ -18,7 +18,8 @@ namespace ProcessEvent
         QJsonDocument jsonDoc;
         if (!message.startsWith("{"))
         {
-            auto str = QString("{\"idx\": %1, \"k\": \"\", \"v\": \"%2\"}").arg(QString::number(index), message);
+            auto str = QString("{\"idx\": %1, \"k\": \"\", \"v\": \"%2\"}")
+                    .arg(QString::number(index), message.replace("\\", "\\\\"));
             jsonDoc = QJsonDocument::fromJson(str.toUtf8());
         }
         else

--- a/src/processevent.cpp
+++ b/src/processevent.cpp
@@ -15,25 +15,26 @@ namespace ProcessEvent
         QStringList m_SkippedText = options.getSkippedText();
         QBitArray m_SkippedState = options.getSkippedState();
 
-        QJsonDocument jsonDoc;
         if (!message.startsWith("{"))
         {
-            auto str = QString("{\"idx\": %1, \"k\": \"\", \"v\": \"%2\"}")
-                    .arg(QString::number(index), message.replace("\\", "\\\\"));
-            jsonDoc = QJsonDocument::fromJson(str.toUtf8());
+            QJsonObject obj;
+            obj["idx"] = index;
+            obj["k"] = "";
+            obj["v"] = message;
+            return obj;
         }
         else
         {
             message.insert(1, QString("\"file\": \"%1\",").arg(fileName));
             message.insert(1, QString("\"idx\": %1,").arg(index));
-            jsonDoc = QJsonDocument::fromJson(message.toUtf8());
+            QJsonDocument jsonDoc = QJsonDocument::fromJson(message.toUtf8());
             if (jsonDoc.object().contains("k")
                     && m_SkippedText.contains(jsonDoc.object()["k"].toString())
                     && m_SkippedState[m_SkippedText.indexOf(jsonDoc.object()["k"].toString(), 0)])
             {
                 jsonDoc = QJsonDocument();
             }
+            return jsonDoc.object();
         }
-        return jsonDoc.object();
     }
 }

--- a/src/valuedlg.cpp
+++ b/src/valuedlg.cpp
@@ -252,9 +252,18 @@ void ValueDlg::VisualizeQuery()
     m_view->setAttribute(Qt::WA_DeleteOnClose);
 
     // Set Qt::Dialog rather than Qt::Window to disable zoom and avoid a Qt bug with unresponsive zoomed views on OSX
-    m_view->setWindowFlags(Qt::Dialog);
-    m_view->resize(1000, 1000);
+    m_view->setWindowFlags(Qt::Dialog | Qt::WindowMaximizeButtonHint | Qt::WindowCloseButtonHint);
     m_view->setWindowTitle(QString("Query Visualization - ID: %1 - Key: %2").arg(m_id, m_key));
+
+    QDesktopWidget widget;
+    int screenId = widget.screenNumber(this);
+    QRect screenRect = widget.availableGeometry(screenId);
+    int width = screenRect.width() - 400;
+    int height = screenRect.height() - 200;
+    int x = screenRect.left() + 200;
+    int y = screenRect.top() + 80;
+    m_view->resize(width, height);
+    m_view->move(x, y);
 
     // Add keyboard shortcut for reloading the view
     QShortcut *shortcut = new QShortcut(QKeySequence("Ctrl+r"), m_view);


### PR DESCRIPTION
Previous fix to display plain text message correctly only address the
"\" cases, but not messages with double quotes.
The cleaner and faster fix is to just set the message string as a value
of QJsonObject directly.

Also fix a compilation warning in options.cpp.