### PR TITLE
Adding ColorLibrary constructor that will omit already used colors. M…

### DIFF
--- a/src/colorlibrary.cpp
+++ b/src/colorlibrary.cpp
@@ -19,12 +19,12 @@ ColorLibrary::ColorLibrary()
     AddColors(DefaultColors);
 }
 
-ColorLibrary::ColorLibrary(QVector<QColor> usedColors)
+ColorLibrary::ColorLibrary(const QVector<QColor>& usedColors)
 {
     Exclude(usedColors);
 }
 
-void ColorLibrary::Exclude(QVector<QColor> usedColors)
+void ColorLibrary::Exclude(const QVector<QColor>& usedColors)
 {
     m_colorLibrary.clear();
 
@@ -41,7 +41,7 @@ void ColorLibrary::Exclude(QVector<QColor> usedColors)
     AddColors(colorsToAddToEnd);
 }
 
-void ColorLibrary::AddColors(QVector<QColor> colors)
+void ColorLibrary::AddColors(const QVector<QColor>& colors)
 {
     for (const auto& color : colors)
     {

--- a/src/colorlibrary.cpp
+++ b/src/colorlibrary.cpp
@@ -1,18 +1,43 @@
 #include "colorlibrary.h"
 
+const static QVector<QColor> DefaultColors =
+{
+    QColor("#f2ec99"),
+    QColor("#bfe4f3"),
+    QColor("#bfe968"),
+    QColor("#c6caf8"),
+    QColor("#eec757"),
+    QColor("#9994f1"),
+    QColor("#edb0e8"),
+    QColor("#cebff3"),
+    QColor("#a5f0c6"),
+    QColor("#f5b0b4")
+};
+
 ColorLibrary::ColorLibrary()
 {
     m_colorLibrary = new QQueue<QColor>();
-    m_colorLibrary->enqueue(QColor("#f2ec99"));
-    m_colorLibrary->enqueue(QColor("#bfe4f3"));
-    m_colorLibrary->enqueue(QColor("#bfe968"));
-    m_colorLibrary->enqueue(QColor("#c6caf8"));
-    m_colorLibrary->enqueue(QColor("#eec757"));
-    m_colorLibrary->enqueue(QColor("#9994f1"));
-    m_colorLibrary->enqueue(QColor("#edb0e8"));
-    m_colorLibrary->enqueue(QColor("#cebff3"));
-    m_colorLibrary->enqueue(QColor("#a5f0c6"));
-    m_colorLibrary->enqueue(QColor("#f5b0b4"));
+    AddColors(DefaultColors);
+}
+
+ColorLibrary::ColorLibrary(QVector<QColor> usedColors)
+{
+    m_colorLibrary = new QQueue<QColor>();
+    QVector<QColor> colorsToAdd;
+    for(const auto& color : DefaultColors)
+    {
+        if (!usedColors.contains(color))
+            colorsToAdd.push_back(color);
+    }
+    AddColors(colorsToAdd);
+}
+
+void ColorLibrary::AddColors(QVector<QColor> colors)
+{
+    for (const auto& color : colors)
+    {
+        m_colorLibrary->enqueue(color);
+    }
 }
 
 QColor ColorLibrary::GetNextColor()
@@ -22,3 +47,5 @@ QColor ColorLibrary::GetNextColor()
     m_colorLibrary->enqueue(color);
     return result;
 }
+
+

--- a/src/colorlibrary.cpp
+++ b/src/colorlibrary.cpp
@@ -16,35 +16,44 @@ const static QVector<QColor> DefaultColors =
 
 ColorLibrary::ColorLibrary()
 {
-    m_colorLibrary = new QQueue<QColor>();
     AddColors(DefaultColors);
 }
 
 ColorLibrary::ColorLibrary(QVector<QColor> usedColors)
 {
-    m_colorLibrary = new QQueue<QColor>();
+    Exclude(usedColors);
+}
+
+void ColorLibrary::Exclude(QVector<QColor> usedColors)
+{
+    m_colorLibrary.clear();
+
     QVector<QColor> colorsToAdd;
+    QVector<QColor> colorsToAddToEnd;
     for(const auto& color : DefaultColors)
     {
         if (!usedColors.contains(color))
             colorsToAdd.push_back(color);
+        else
+            colorsToAddToEnd.push_back(color);
     }
     AddColors(colorsToAdd);
+    AddColors(colorsToAddToEnd);
 }
 
 void ColorLibrary::AddColors(QVector<QColor> colors)
 {
     for (const auto& color : colors)
     {
-        m_colorLibrary->enqueue(color);
+        m_colorLibrary.enqueue(color);
     }
 }
 
 QColor ColorLibrary::GetNextColor()
 {
-    QColor result = m_colorLibrary->head();
-    auto color = m_colorLibrary->dequeue();
-    m_colorLibrary->enqueue(color);
+    QColor result = m_colorLibrary.head();
+    auto color = m_colorLibrary.dequeue();
+    m_colorLibrary.enqueue(color);
     return result;
 }
 

--- a/src/colorlibrary.h
+++ b/src/colorlibrary.h
@@ -12,13 +12,13 @@ class ColorLibrary
 {
 public:
     ColorLibrary();
-    ColorLibrary(QVector<QColor> usedColors);
+    ColorLibrary(const QVector<QColor>& usedColors);
 
-    void Exclude(QVector<QColor> usedColors);
+    void Exclude(const QVector<QColor>& usedColors);
     QColor GetNextColor();
 
 private:
     QQueue<QColor> m_colorLibrary;
-    void AddColors(QVector<QColor> colors);
+    void AddColors(const QVector<QColor>& colors);
 };
 #endif // COLORLIBRARY_H

--- a/src/colorlibrary.h
+++ b/src/colorlibrary.h
@@ -1,6 +1,7 @@
 #ifndef COLORLIBRARY_H
 #define COLORLIBRARY_H
 
+#include <QVector>
 #include <QColor>
 #include <QQueue>
 
@@ -8,10 +9,11 @@ class ColorLibrary
 {
 public:
     ColorLibrary();
+    ColorLibrary(QVector<QColor> usedColors);
     QColor GetNextColor();
-    void AddColor(QColor color);
 
 private:
     QQueue<QColor> * m_colorLibrary;
+    void AddColors(QVector<QColor> colors);
 };
 #endif // COLORLIBRARY_H

--- a/src/colorlibrary.h
+++ b/src/colorlibrary.h
@@ -5,15 +5,20 @@
 #include <QColor>
 #include <QQueue>
 
+// The purpose of this class is to provide some default colors for highlight filters.
+// Default colors are stored in a queue and once a color is used, it is enqueued again.
+// If a color is being used from a loaded filter, it will be moved to the end of the queue.
 class ColorLibrary
 {
 public:
     ColorLibrary();
     ColorLibrary(QVector<QColor> usedColors);
+
+    void Exclude(QVector<QColor> usedColors);
     QColor GetNextColor();
 
 private:
-    QQueue<QColor> * m_colorLibrary;
+    QQueue<QColor> m_colorLibrary;
     void AddColors(QVector<QColor> colors);
 };
 #endif // COLORLIBRARY_H

--- a/src/highlightdlg.cpp
+++ b/src/highlightdlg.cpp
@@ -12,7 +12,7 @@
 #include <QLineEdit>
 #include <QMap>
 
-HighlightDlg::HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, ColorLibrary * colorLibrary) :
+HighlightDlg::HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, ColorLibrary colorLibrary) :
     QDialog(parent),
     ui(new Ui::HighlightDlg)
 {
@@ -74,7 +74,7 @@ void HighlightDlg::AddNewTab()
     auto newFilter = new FilterTab(nullptr, m_filterTabValueLabel);
     ui->tabWidget->addTab(newFilter, "   ");
     ui->tabWidget->setCurrentIndex(ui->tabWidget->indexOf(newFilter));
-    newFilter->SetBackgroundColor(m_colors->GetNextColor());
+    newFilter->SetBackgroundColor(m_colors.GetNextColor());
 
     connect(newFilter, &FilterTab::filterValueChanged, this, &HighlightDlg::TextChanged);
 }

--- a/src/highlightdlg.cpp
+++ b/src/highlightdlg.cpp
@@ -12,7 +12,7 @@
 #include <QLineEdit>
 #include <QMap>
 
-HighlightDlg::HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, ColorLibrary colorLibrary) :
+HighlightDlg::HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, const ColorLibrary& colorLibrary) :
     QDialog(parent),
     ui(new Ui::HighlightDlg)
 {
@@ -22,7 +22,7 @@ HighlightDlg::HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, Colo
     // Remove close button of the Help tab.
     ui->tabWidget->tabBar()->tabButton(0, QTabBar::RightSide)->resize(0, 0);
 
-    m_colors = colorLibrary;
+    m_colorLibrary = colorLibrary;
     connect(this, &QDialog::accepted, this, &HighlightDlg::accepted);
     BuildTabs(highlightOpts);
 }
@@ -74,7 +74,7 @@ void HighlightDlg::AddNewTab()
     auto newFilter = new FilterTab(nullptr, m_filterTabValueLabel);
     ui->tabWidget->addTab(newFilter, "   ");
     ui->tabWidget->setCurrentIndex(ui->tabWidget->indexOf(newFilter));
-    newFilter->SetBackgroundColor(m_colors.GetNextColor());
+    newFilter->SetBackgroundColor(m_colorLibrary.GetNextColor());
 
     connect(newFilter, &FilterTab::filterValueChanged, this, &HighlightDlg::TextChanged);
 }

--- a/src/highlightdlg.h
+++ b/src/highlightdlg.h
@@ -18,11 +18,12 @@ class HighlightDlg : public QDialog
     Q_OBJECT
 
 public:
-    HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, ColorLibrary * colorLibrary);
+    HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, ColorLibrary colorLibrary);
     ~HighlightDlg();
     void keyPressEvent(QKeyEvent * k);
 
     HighlightOptions m_highlightOpts;
+    ColorLibrary m_colors;
 
 private slots:
     void on_tabWidget_tabCloseRequested(int index);
@@ -38,7 +39,6 @@ private:
     void accepted();
 
     Ui::HighlightDlg *ui;
-    ColorLibrary * m_colors;
     const QString m_filterTabValueLabel = "Highlight &log event values that contains substring:";
     const int m_tabLabelSize = 20;
 };

--- a/src/highlightdlg.h
+++ b/src/highlightdlg.h
@@ -18,12 +18,12 @@ class HighlightDlg : public QDialog
     Q_OBJECT
 
 public:
-    HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, ColorLibrary colorLibrary);
+    HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, const ColorLibrary& colorLibrary);
     ~HighlightDlg();
     void keyPressEvent(QKeyEvent * k);
 
     HighlightOptions m_highlightOpts;
-    ColorLibrary m_colors;
+    ColorLibrary m_colorLibrary;
 
 private slots:
     void on_tabWidget_tabCloseRequested(int index);

--- a/src/highlightoptions.cpp
+++ b/src/highlightoptions.cpp
@@ -29,3 +29,11 @@ void HighlightOptions::FromJson(const QJsonArray& json)
         this->append(highlightFilter);
     }
 }
+
+QVector<QColor> HighlightOptions::GetColors()
+{
+    QVector<QColor> result;
+    for (auto searchOpt : *this)
+        result.push_back(searchOpt.m_backgroundColor);
+    return result;
+}

--- a/src/highlightoptions.cpp
+++ b/src/highlightoptions.cpp
@@ -22,7 +22,7 @@ QJsonArray HighlightOptions::ToJson()
 void HighlightOptions::FromJson(const QJsonArray& json)
 {
     clear();
-    for (auto filterJson : json)
+    for (const auto& filterJson : json)
     {
         SearchOpt highlightFilter;
         highlightFilter.FromJson(filterJson.toObject());
@@ -33,7 +33,7 @@ void HighlightOptions::FromJson(const QJsonArray& json)
 QVector<QColor> HighlightOptions::GetColors()
 {
     QVector<QColor> result;
-    for (auto searchOpt : *this)
+    for (const auto &searchOpt : *this)
         result.push_back(searchOpt.m_backgroundColor);
     return result;
 }

--- a/src/highlightoptions.h
+++ b/src/highlightoptions.h
@@ -14,6 +14,7 @@ public:
     HighlightOptions(const QJsonArray& json);
     QJsonArray ToJson();
     void FromJson(const QJsonArray& json);
+    QVector<QColor> GetColors();
 };
 
 #endif // HIGHLIGHTOPTIONS_H

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -812,7 +812,7 @@ void LogTab::RowHighlightSelectedType()
     SearchOpt newOpt;
     newOpt.m_keys.append(COL::Key);
     newOpt.m_value = idx.model()->index(idx.row(), COL::Key, idx.parent()).data().toString();
-    newOpt.m_backgroundColor = m_treeModel->m_colorLibrary->GetNextColor();
+    newOpt.m_backgroundColor = m_treeModel->m_colorLibrary.GetNextColor();
     m_treeModel->m_highlightOpts.append(newOpt);
     menuUpdateNeeded();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -718,16 +718,14 @@ void MainWindow::on_actionHighlight_triggered()
         return;
 
     // Construct a highlight dialog with our model's current _HighlightOpts.
-    HighlightDlg highlightDlg(this, model->m_highlightOpts, model->m_colorLibrary);
+    ColorLibrary * colorLibrary = new ColorLibrary(model->m_highlightOpts.GetColors());
+    HighlightDlg highlightDlg(this, model->m_highlightOpts, colorLibrary);
 
     // Open the dialog and see if ok was pressed. If so we want to update our model's _HighlightOpts member.
     if (highlightDlg.exec() == QDialog::Accepted)
     {
-        model->m_highlightOpts = highlightDlg.m_highlightOpts;
-        if (!model->HasFilters())
-        {
-            model->m_highlightOnlyMode = false;
-        }
+        model->UpdateHighlights(highlightDlg.m_highlightOpts);
+
         RefilterTreeView();
         UpdateMenuAndStatusBar();
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -718,13 +718,18 @@ void MainWindow::on_actionHighlight_triggered()
         return;
 
     // Construct a highlight dialog with our model's current _HighlightOpts.
-    ColorLibrary * colorLibrary = new ColorLibrary(model->m_highlightOpts.GetColors());
-    HighlightDlg highlightDlg(this, model->m_highlightOpts, colorLibrary);
+    HighlightDlg highlightDlg(this, model->m_highlightOpts, model->m_colorLibrary);
 
     // Open the dialog and see if ok was pressed. If so we want to update our model's _HighlightOpts member.
     if (highlightDlg.exec() == QDialog::Accepted)
     {
-        model->UpdateHighlights(highlightDlg.m_highlightOpts);
+        model->m_highlightOpts = highlightDlg.m_highlightOpts;
+        model->m_colorLibrary = highlightDlg.m_colors;
+
+        if (!model->HasFilters())
+        {
+            model->m_highlightOnlyMode = false;
+        }
 
         RefilterTreeView();
         UpdateMenuAndStatusBar();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -724,7 +724,7 @@ void MainWindow::on_actionHighlight_triggered()
     if (highlightDlg.exec() == QDialog::Accepted)
     {
         model->m_highlightOpts = highlightDlg.m_highlightOpts;
-        model->m_colorLibrary = highlightDlg.m_colors;
+        model->m_colorLibrary = highlightDlg.m_colorLibrary;
 
         if (!model->HasFilters())
         {

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -21,11 +21,7 @@ TreeModel::TreeModel(const QStringList &headers, const EventListPtr events, QObj
     if (!defaultHighlightOpts.isEmpty())
     {
         m_highlightOpts = defaultHighlightOpts;
-        m_colorLibrary = new ColorLibrary(m_highlightOpts.GetColors());
-    }
-    else
-    {
-        m_colorLibrary = new ColorLibrary();
+        m_colorLibrary.Exclude(m_highlightOpts.GetColors());
     }
 
     m_highlightOnlyMode = false;
@@ -35,7 +31,6 @@ TreeModel::TreeModel(const QStringList &headers, const EventListPtr events, QObj
 TreeModel::~TreeModel()
 {
     delete m_rootItem;
-    delete m_colorLibrary;
 }
 
 int TreeModel::columnCount(const QModelIndex & /* parent */) const
@@ -572,19 +567,6 @@ void TreeModel::GetFlatJson(const QString& key, const QJsonValue& value, QVector
     else
     {
         stringList.append(KeyValueString(key, value.toString()));
-    }
-}
-
-void TreeModel::UpdateHighlights(HighlightOptions opts)
-{
-    m_highlightOpts = opts;
-
-    delete m_colorLibrary;
-    m_colorLibrary = new ColorLibrary(opts.GetColors());
-
-    if (!HasFilters())
-    {
-        m_highlightOnlyMode = false;
     }
 }
 

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -19,9 +19,15 @@ TreeModel::TreeModel(const QStringList &headers, const EventListPtr events, QObj
 
     HighlightOptions defaultHighlightOpts = Options::GetInstance().getDefaultHighlightOpts();
     if (!defaultHighlightOpts.isEmpty())
+    {
         m_highlightOpts = defaultHighlightOpts;
+        m_colorLibrary = new ColorLibrary(m_highlightOpts.GetColors());
+    }
+    else
+    {
+        m_colorLibrary = new ColorLibrary();
+    }
 
-    m_colorLibrary = new ColorLibrary();
     m_highlightOnlyMode = false;
     m_liveMode = false;
 }
@@ -566,6 +572,19 @@ void TreeModel::GetFlatJson(const QString& key, const QJsonValue& value, QVector
     else
     {
         stringList.append(KeyValueString(key, value.toString()));
+    }
+}
+
+void TreeModel::UpdateHighlights(HighlightOptions opts)
+{
+    m_highlightOpts = opts;
+
+    delete m_colorLibrary;
+    m_colorLibrary = new ColorLibrary(opts.GetColors());
+
+    if (!HasFilters())
+    {
+        m_highlightOnlyMode = false;
     }
 }
 

--- a/src/treemodel.h
+++ b/src/treemodel.h
@@ -63,12 +63,14 @@ public:
     QJsonObject GetEvent(QModelIndex idx) const;
     TABTYPE TabType() const;
     void SetTabType(TABTYPE type);
+    void UpdateHighlights(HighlightOptions opts);
+
 
     bool m_highlightOnlyMode;
     bool m_liveMode;
     HighlightOptions m_highlightOpts;
-    SearchOpt m_findOpts;
     ColorLibrary * m_colorLibrary;
+    SearchOpt m_findOpts;
     QList<QString> m_paths;
 
 private:

--- a/src/treemodel.h
+++ b/src/treemodel.h
@@ -63,13 +63,11 @@ public:
     QJsonObject GetEvent(QModelIndex idx) const;
     TABTYPE TabType() const;
     void SetTabType(TABTYPE type);
-    void UpdateHighlights(HighlightOptions opts);
-
 
     bool m_highlightOnlyMode;
     bool m_liveMode;
     HighlightOptions m_highlightOpts;
-    ColorLibrary * m_colorLibrary;
+    ColorLibrary m_colorLibrary;
     SearchOpt m_findOpts;
     QList<QString> m_paths;
 


### PR DESCRIPTION
This change makes it so when you load a highlight filter (either through default highlight filter or manually), the constructed ColorLibrary will omit the already used colors. This prevents you from getting duplicate default colors when you are adding on to a loaded filter.

Changes made

- ColorLibrary: Added extra constructor, and moved default colors to a static vector.
- HighlightOpts: Added interface to get a vector of the colors
- MainWindow: Modifed on_actionHighlight_triggered() to properly pass in the correct ColorLibrary to the HighlightDlg.
- TreeModel: Created an UpdateHighlights() function that will update the m_colorLibrary when updating the m_highlightOpts. I believe the only current use case for this is in the MainWindow change above.

Testing done:
Verified that no duplicate colors were generated for
- Loaded default highlight filters
- Manually loaded a filter
