### PR TITLE
Directory live capture improvement for server logs, P2

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -41,6 +41,7 @@ void LogTab::InitTreeView(const EventListPtr events)
 
     bool hasNoKey = (events->size() > 0 && events->at(0)["k"].toString().isEmpty());
 
+    ui->treeView->SetAutoResizeColumns({COL::Time, COL::Elapsed});
     SetColumn(COL::ID, 80, false);
     SetColumn(COL::File, 110, true);
     SetColumn(COL::Time, 190, hasNoKey);
@@ -56,7 +57,6 @@ void LogTab::InitTreeView(const EventListPtr events)
 
     ui->treeView->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->treeView->header()->setContextMenuPolicy(Qt::CustomContextMenu);
-    ui->treeView->SetAutoResizeColumns({COL::Time, COL::Elapsed});
 
     // Connect slots
     connect(ui->treeView, SIGNAL(doubleClicked(QModelIndex)),
@@ -171,22 +171,34 @@ void LogTab::keyPressEvent(QKeyEvent *event)
         }
         UpdateStatusBar();
         break;
-    case Qt::Key_C:
-        if ((QApplication::keyboardModifiers() & Qt::ControlModifier) &&
+    default:
+        // Check keys with modifiers together and ensure regular key events get propagated.
+        if ((event->key() == Qt::Key_C) &&
+            (QApplication::keyboardModifiers() & Qt::ControlModifier) &&
             (rowCount > 0))
         {
             CopyItemDetails(idxList);
         }
-        break;
-    case Qt::Key_D:
-        if ((QApplication::keyboardModifiers() & Qt::ControlModifier) &&
-            (rowCount == 2))
+        else if ((event->key() == Qt::Key_D) &&
+                 (QApplication::keyboardModifiers() & Qt::ControlModifier) &&
+                 (rowCount == 2))
         {
             RowDiffEvents();
         }
-        break;
-    default:
-        QWidget::keyPressEvent(event);
+        else if ((event->key() == Qt::Key_I) &&
+                 (QApplication::keyboardModifiers() & Qt::ControlModifier) &&
+                 (QApplication::keyboardModifiers() & Qt::ShiftModifier))
+        {
+            QMessageBox msgBox(this);
+            msgBox.setWindowTitle("Debug Info");
+            msgBox.setText(GetDebugInfo());
+            msgBox.setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
+            msgBox.exec();
+        }
+        else
+        {
+            QWidget::keyPressEvent(event);
+        }
     }
 }
 
@@ -255,14 +267,11 @@ void LogTab::SetUpFile(std::shared_ptr<QFile> file)
     {
         int offset = file->size();
         file->seek(offset);
-        qDebug() << "SetUpFile Add:" << file->fileName();
         m_directoryFiles[file->fileName()] = file;
     }
     else
     {
         file->close();
-        qDebug() << "SetUpFile Exclude:" << file->fileName();
-        qDebug() << "  line:" << line;
         m_excludedFileNames.append(file->fileName());
     }
 }
@@ -272,7 +281,6 @@ void LogTab::StartDirectoryLiveCapture()
     SetColumn(COL::File, 110, false);
     m_eventIndex = 1;
     m_treeModel->m_liveMode = true;
-    m_firstLiveRead = true;
     QStringList files = m_liveDirectory->entryList(QDir::Files);
     for (const QString& fileName : files)
     {
@@ -351,11 +359,6 @@ void LogTab::UpdateModelView()
     if (ui->treeView->verticalScrollBar()->value() == ui->treeView->verticalScrollBar()->maximum())
     {
         ui->treeView->scrollToBottom();
-    }
-    if (m_firstLiveRead)
-    {
-        ui->treeView->resizeColumnToContents(COL::Time);
-        m_firstLiveRead = false;
     }
 }
 
@@ -907,4 +910,34 @@ void LogTab::UpdateStatusBar()
 
     status += QString("events: %1  ").arg(m_treeModel->rowCount());
     m_bar->SetRightLabelText(status);
+}
+
+QString LogTab::GetDebugInfo() const
+{
+    QString tabType;
+    QString extra;
+    if (m_treeModel->TabType() == TABTYPE::SingleFile)
+    {
+        tabType = "Single File";
+    }
+    else if (m_treeModel->TabType() == TABTYPE::Directory)
+    {
+        tabType = "Directory";
+        extra = "Monitoring files:\n  Include:\n";
+        for (const QString& file : m_directoryFiles.keys())
+        {
+            extra += QString("    %1\n").arg(file);
+        }
+        extra += "  Exclude:\n";
+        for (const auto& file : m_excludedFileNames)
+        {
+            extra += QString("    %1\n").arg(file);
+        }
+    }
+    else if (m_treeModel->TabType() == TABTYPE::ExportedEvents)
+    {
+        tabType = "Exported Events";
+    }
+
+    return QString("Type: %1\nPath: %2\n\n%3").arg(tabType).arg(m_tabPath).arg(extra);
 }

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -366,8 +366,15 @@ bool LogTab::StartFileLiveCapture()
 {
     QModelIndex idx = m_treeModel->index(m_treeModel->rowCount() - 1, 0);
     auto item_model = idx.model();
-    auto idx_info = item_model->index(idx.row(), COL::ID, idx.parent());
-    m_eventIndex = idx_info.data().toInt() + 1;
+    if (item_model)
+    {
+        auto idx_info = item_model->index(idx.row(), COL::ID, idx.parent());
+        m_eventIndex = idx_info.data().toInt() + 1;
+    }
+    else
+    {
+        m_eventIndex = 1;
+    }
 
     // Open file/check file exists and is readable
     if (!m_logFile.exists())

--- a/src/logtab.h
+++ b/src/logtab.h
@@ -52,6 +52,7 @@ private:
     void TrimEventCount();
     bool StartFileLiveCapture();
     void StartDirectoryLiveCapture();
+    QString GetDebugInfo() const;
 
     Ui::LogTab *ui;
     StatusBar *m_bar;
@@ -70,7 +71,6 @@ private:
     std::unique_ptr<QDir> m_liveDirectory;
     QHash<QString, std::shared_ptr<QFile>> m_directoryFiles;
     QList<QString> m_excludedFileNames;
-    bool m_firstLiveRead;
     QString m_tabPath;
 
 private slots:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -394,7 +394,7 @@ void MainWindow::StartDirectoryLiveCapture(QString directoryPath, QString label)
         if (label.isEmpty())
         {
             QFileInfo fi(directoryPath);
-            label = QString("Directory: %1").arg(fi.fileName());
+            label = QString("%1 directory").arg(fi.fileName());
         }
         EventListPtr events = std::make_shared<EventList>();
         SetUpTab(events, true, directoryPath, label);
@@ -450,7 +450,7 @@ void MainWindow::CheckFileOpened(QString path)
         QTreeView * view = GetTreeView(i);
         TreeModel * model = GetTreeModel(view);
         LogTab * currentTab = m_logTabs[model];
-        if ((model->TabType() == TABTYPE::Directory || model->TabType() == TABTYPE::SingleFile) && currentTab->GetTabPath().compare(path) == 0)
+        if (currentTab && currentTab->GetTabPath().compare(path) == 0)
         {
             tabWidget->setCurrentIndex(i);
         }
@@ -717,6 +717,8 @@ void MainWindow::on_actionClose_all_tabs_triggered()
         currentTab->EndLiveCapture();
     }
     tabWidget->clear();
+    m_logTabs.clear();
+    m_allFiles.clear();
     UpdateMenuAndStatusBar();
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -104,7 +104,7 @@ private:
     void FindNextH();
     void FindImplH(int offset);
 
-    void StartDirectoryLiveCapture(QString directoryPath, const QString& label);
+    void StartDirectoryLiveCapture(QString directoryPath, QString label);
     void CheckFileOpened(QString path);
     LogTab* SetUpTab(EventListPtr events, bool isDirectory, QString path, QString label);
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -319,6 +319,9 @@ QTabWidget::tab-bar {
    <property name="shortcut">
     <string>Ctrl+T</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionClear_Recent_Files">
    <property name="text">

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -357,7 +357,7 @@ void TreeModel::SetupChild(TreeItem *child, const QJsonObject & event)
     child->SetData(COL::ID, event["idx"].toInt());
     child->SetData(COL::File, event["file"].toString());
     child->SetData(COL::Time, QDateTime::fromString(QString(event["ts"].toString()), "yyyy-MM-ddTHH:mm:ss.zzz"));
-    child->SetData(COL::PID, event["pid"].toString());
+    child->SetData(COL::PID, event["pid"].toInt());
     child->SetData(COL::TID, event["tid"].toString());
     child->SetData(COL::Severity, event["sev"].toString());
     child->SetData(COL::Request, event["req"].toString());

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -295,6 +295,12 @@ void TreeModel::SetTabType(TABTYPE type)
 int TreeModel::MergeIntoModelData(const EventList& events)
 {
     int origIter = m_rootItem->ChildCount() - 1;
+    if (events[0]["ts"].toString().isEmpty())
+    {
+        AddToModelData(events);
+        return origIter;
+    }
+
     for (int mergeIter = events.size() - 1; mergeIter >= 0; mergeIter--)
     {
         QDateTime mergeTime = QDateTime::fromString(events[mergeIter]["ts"].toString(), "yyyy-MM-ddTHH:mm:ss.zzz");
@@ -325,11 +331,11 @@ int TreeModel::MergeIntoModelData(const EventList& events)
 
 void TreeModel::AddToModelData(const EventList& events)
 {
-    foreach(auto event, events)
+    for (const auto& event : events)
     {
         InsertChild(m_rootItem->ChildCount(), event);
-        layoutChanged();
     }
+    layoutChanged();
 }
 
 void TreeModel::InsertChild(int position, const QJsonObject & event)


### PR DESCRIPTION
- Fix: "pid" field from json logs was not parsed and set.
- Fix a crash due to close all not clearing all states.
- Fix crash on starting live capture of empty file tabs.
- Allow drag and drop directories from Explorer/Finder to the TLV to
live capture them directly.
- Use file path of the current tab for new directory live capture. The
current default is the TLV install directory, which is never useful.
Combined with the open log file context menu feature, it's easy to
switch between monitoring a file and its container directory.
- Always add new non-json logs to the bottom in live capture, instead of
merged to the top.
- Set directory live capture tab title to begin with directory name
for better differentiation.
- Use a default fixed column size for timestamp column, so we don't
incorrectly auto-resize based on non-json logs that do not have
timestamp.
- Add "hidden" debug info message box (Ctrl-Shift-I) to show what files
are being monitored.
- Hide the Show Timeline menu item that is not yet implemented.
