### PR TITLE
Allow spaces, dashes, and dots when saving filters

### DIFF
--- a/src/savefilterdialog.cpp
+++ b/src/savefilterdialog.cpp
@@ -55,7 +55,7 @@ bool SaveFilterDialog::SaveFilter(const QString& filename)
         QMessageBox validationWarning(
             QMessageBox::Icon::Warning,
             QStringLiteral("Invalid name"),
-            QStringLiteral("Only alphanumeric characters and underscores are allowed."));
+            QStringLiteral("Only alphanumeric characters, underscores, dashes, periods, and spaces are allowed."));
         validationWarning.exec();
         return false;
     }

--- a/src/savefilterdialog.cpp
+++ b/src/savefilterdialog.cpp
@@ -49,7 +49,7 @@ bool SaveFilterDialog::SaveFilter(const QString& filename)
     qDebug() << "attempting to save...";
 
     // Validate filename
-    QRegularExpression regex("^[a-z0-9-_ ]+$", QRegularExpression::CaseInsensitiveOption);
+    QRegularExpression regex("^[a-z0-9.\\-_ ]+$", QRegularExpression::CaseInsensitiveOption);
     if (!regex.match(filename).hasMatch())
     {
         QMessageBox validationWarning(

--- a/src/savefilterdialog.cpp
+++ b/src/savefilterdialog.cpp
@@ -49,7 +49,7 @@ bool SaveFilterDialog::SaveFilter(const QString& filename)
     qDebug() << "attempting to save...";
 
     // Validate filename
-    QRegularExpression regex("^[a-z0-9_]+$", QRegularExpression::CaseInsensitiveOption);
+    QRegularExpression regex("^[a-z0-9-_ ]+$", QRegularExpression::CaseInsensitiveOption);
     if (!regex.match(filename).hasMatch())
     {
         QMessageBox validationWarning(


### PR DESCRIPTION
From http://superuser.com/questions/358855/what-characters-are-safe-in-cross-platform-file-names-for-linux-windows-and-os
It seems like we can safely allow dashes and spaces when saving filters to files. 

Did a quick test to save a filter named "test this-filter_out", and "test this-filter_out.json" was successfully created.

Let me know if there are any other restrictions you think should be restricted.

fixes #6 