### PR TITLE
Fix UI stutters whenever there are large queries in view

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -170,7 +170,6 @@ void LogTab::keyPressEvent(QKeyEvent *event)
             auto idx = idxList.at(i-1);
             m_treeModel->removeRow(idx.row(), idx.parent());
         }
-        UpdateStatusBar();
         break;
     default:
         // Check keys with modifiers together and ensure regular key events get propagated.
@@ -708,10 +707,7 @@ void LogTab::RowDiffEvents()
 void LogTab::RowHideSelected()
 {
     QModelIndex index = ui->treeView->selectionModel()->currentIndex();
-    if (m_treeModel->removeRow(index.row(), index.parent()))
-    {
-        UpdateStatusBar();
-    }
+    m_treeModel->removeRow(index.row(), index.parent());
 }
 
 void LogTab::RowHideSelectedType()
@@ -731,7 +727,6 @@ void LogTab::RowHideSelectedType()
     }
     ui->treeView->setUpdatesEnabled(true);
 
-    UpdateStatusBar();
     m_bar->ShowMessage(QString("%1 '%2' event(s) hidden").arg(QString::number(count), key), 3000);
 }
 
@@ -902,10 +897,9 @@ void LogTab::UpdateStatusBar()
             }
             status += highlightOpt.m_value;
         }
-        status += "}  |  ";
+        status += "}";
     }
 
-    status += QString("events: %1  ").arg(m_treeModel->rowCount());
     m_bar->SetRightLabelText(status);
 }
 

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -16,6 +16,7 @@ LogTab::LogTab(QWidget *parent, StatusBar *bar, const EventListPtr events) :
     m_bar(bar)
 {
     ui->setupUi(this);
+    setFocusProxy(ui->treeView);
     InitTreeView(events);
     InitMenus();
 }

--- a/src/logtab.h
+++ b/src/logtab.h
@@ -26,6 +26,7 @@ public:
     void EndLiveCapture();
     QString GetTabPath() const;
     void SetTabPath(const QString& path);
+    void UpdateStatusBar();
 
 private:
     void keyPressEvent(QKeyEvent *event) override;
@@ -42,7 +43,6 @@ private:
     void RowFindPrev();
     void RowFindNext();
     void RowFindImpl(int offset);
-    void UpdateStatusBar();
     void ShowDetails(const QModelIndex& idx, ValueDlg& valueDlg);
     void ReadFile();
     void ReadDirectoryFiles();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -237,6 +237,7 @@ void MainWindow::ExportEventsToTab(QModelIndexList list)
     connect(logTab, &LogTab::exportToTab, this, &MainWindow::ExportEventsToTab);
     int idx = tabWidget->addTab(logTab, "exported data");
     tabWidget->setCurrentIndex(idx);
+    logTab->setFocus();
 
     QTreeView * exportedView = GetCurrentTreeView();
     TreeModel * exportedModel = GetCurrentTreeModel();
@@ -433,6 +434,8 @@ LogTab* MainWindow::SetUpTab(EventListPtr events, bool isDirectory, QString path
 
     tabWidget->setTabToolTip(idx, path);
     tabWidget->setCurrentIndex(idx);
+    logTab->setFocus();
+
     bool futureTabsUnderLive = m_options.getFutureTabsUnderLive();
     if (isDirectory || futureTabsUnderLive)
     {
@@ -453,6 +456,7 @@ void MainWindow::CheckFileOpened(QString path)
         if (currentTab && currentTab->GetTabPath().compare(path) == 0)
         {
             tabWidget->setCurrentIndex(i);
+            currentTab->setFocus();
         }
     }
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -138,22 +138,11 @@ void MainWindow::UpdateMenuAndStatusBar()
         return;
     }
 
-    QString status = "";
-    if (!model->m_highlightOpts.isEmpty())
+    LogTab* currentTab = m_logTabs[model];
+    if (currentTab)
     {
-        status += model->m_highlightOnlyMode ? "show only highlighted: {" : "highlighted: {";
-        for(int i=0; i<model->m_highlightOpts.count(); i++)
-        {
-            SearchOpt highlightOpt = model->m_highlightOpts[i];
-            if(i!=0)
-                status += ", ";
-            status += highlightOpt.m_value;
-        }
-        status += "}  |  ";
+        currentTab->UpdateStatusBar();
     }
-
-    status += QString("events: %1  ").arg(model->rowCount());
-    m_statusBarLabel->setText(status);
 }
 
 void MainWindow::WriteSettings()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -99,10 +99,9 @@ private:
     void MergeLogFile(QString path);
     void FindPrev();
     void FindNext();
-    void FindImpl(int offset);
     void FindPrevH();
     void FindNextH();
-    void FindImplH(int offset);
+    void FindImpl(int offset, bool findHighlight);
 
     void StartDirectoryLiveCapture(QString directoryPath, QString label);
     void CheckFileOpened(QString path);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -21,7 +21,7 @@ void Options::ReadSettings()
     m_diffToolPath = settings.value("diffToolPath", defaultDiffToolPath).toString();
     m_futureTabsUnderLive = settings.value("enableLiveCapture").toBool();
     m_defaultFilterName = settings.value("defaultHighlightFilter", "None").toString();
-    m_captureAllTextFiles = settings.value("liveCaptureAllTextFiles").toBool();
+    m_captureAllTextFiles = settings.value("liveCaptureAllTextFiles", true).toBool();
 
     settings.endGroup();
 

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -387,8 +387,8 @@ void SetValueDisplayString(TreeItem* child, QString str)
     // Limit string size in the tree view to prevent UI stutters.
     const int MaxDisplayStringSize = 300;
 
-    str.replace("\n", " ");
     str.truncate(MaxDisplayStringSize);
+    str.replace("\n", " ");
     child->SetData(COL::Value, str);
 }
 

--- a/src/treemodel.h
+++ b/src/treemodel.h
@@ -52,7 +52,7 @@ public:
     bool insertRows(int position, int rows, const QModelIndex &parent = QModelIndex()) override;
     bool removeRows(int position, int rows, const QModelIndex &parent = QModelIndex()) override;
 
-    TreeItem* GetFirstChildWithKey(const QModelIndex &index, QString key) const;
+    QString GetChildValueString(const QModelIndex &index, QString key) const;
     int MergeIntoModelData(const EventList& events);
     void AddToModelData(const EventList& events);
     bool HasFilters();
@@ -61,6 +61,7 @@ public:
     void ShowDeltas(qint64 delta);
     bool IsHighlightedRow(int row) const;
     QJsonObject GetEvent(QModelIndex idx) const;
+    QString GetValueFullString(const QModelIndex& idx, bool singleLineFormat = false) const;
     TABTYPE TabType() const;
     void SetTabType(TABTYPE type);
 
@@ -77,12 +78,11 @@ private:
     void AddChildren(QJsonObject &obj, TreeItem *parent);
     void AddChild(const QString& key, const QJsonValue& value, TreeItem* parent);
     void InsertChild(int position, const QJsonObject & event);
-    const QString KeyValueString(const QString& key, const QString& value);
-    const QString JsonToString(const QJsonObject& json);
-    void GetFlatJson(const QJsonObject& json, QVector<QString>& stringList);
-    void GetFlatJson(const QString& key, const QJsonValue& value, QVector<QString>& stringList);
-    QColor ItemHighlightColor(TreeItem * item) const;
-    bool EventHighlightMatch(const QJsonObject & event, const ColumnKeys & map);
+    const QString KeyValueString(const QString& key, const QString& value) const;
+    QString JsonToString(const QJsonObject& json, const QString& lineBreak = "; ") const;
+    void GetFlatJson(const QJsonObject& json, QVector<QString>& stringList) const;
+    void GetFlatJson(const QString& key, const QJsonValue& value, QVector<QString>& stringList) const;
+    QColor ItemHighlightColor(const QModelIndex& idx) const;
     QString GetDeltaMSecs(QDateTime dateTime) const;
     TreeItem *GetItem(const QModelIndex &index) const;
 


### PR DESCRIPTION
- Fix UI stutters whenever there are large queries in view.

When there are large event messages, such as 10K+ chars long queries, the UI begin stutters excessively even without any live update or filtering.
This appears is due to Qt tree view handling of large strings. This change limits the number of characters shown in tree view value items to 300 qchars.
All  code that needs the value strings will now call a new method to get the full string from the corresponding QJsonObject.

Tested affected areas:
 Show details (could still be slow to show for very large strings with syntax highlights)
 query viz
 copy-paste items
 diff two events (now sub-objects are in separate lines)
 show summary
 find previous/next (fix missing search with single line tabs)
 find previous/next highlight (fix an infinite loop with empty tabs)
 highlights matches strings outside of truncated value strings

- Fix out of sync event count in status bar in live capture mode.
Remove event count from status bar.
Reconstruct the status message and refresh the status bar every 0.25
second in live mode is not particularly efficient. Since we can easyly
get this info from the Show Summary feature with a shortcut key, this
can be removed instead.
Also remove the duplicated code.

- Default live capture all text files to true.