### PR TITLE
reorder init list for highlightdlg to fix clang warning

### DIFF
--- a/src/highlightdlg.cpp
+++ b/src/highlightdlg.cpp
@@ -14,8 +14,8 @@
 
 HighlightDlg::HighlightDlg(QWidget *parent, HighlightOptions highlightOpts, const ColorLibrary& colorLibrary) :
     QDialog(parent),
-    ui(new Ui::HighlightDlg),
-    m_colorLibrary(colorLibrary)
+    m_colorLibrary(colorLibrary),
+    ui(new Ui::HighlightDlg)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);


### PR DESCRIPTION
Clang has a warning when the initializer list order is not the same as the member variable order.

Re-ordering initializer list, as m_colorLibrary is public and ui is private, so they cannot really be re-ordered.