### PR TITLE
Copy items to clipboard in Excel friendly format

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -923,7 +923,7 @@ void LogTab::UpdateStatusBar()
                 break;
             }
         }
-        status += "}  ";
+        status += "}";
     }
 
     m_bar->SetRightLabelText(status);

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -588,10 +588,22 @@ void LogTab::ChangePrevIndex()
 void LogTab::CopyItemDetails(const QModelIndexList& idxList)
 {
     QString copyText;
+    int columnCount = m_treeModel->columnCount();
+
+    // Header row
+    for (int i = 0; i < columnCount; i++)
+    {
+        if (!(ui->treeView->isColumnHidden(i)))
+        {
+            QString info = m_treeModel->headerData(i, Qt::Horizontal).toString();
+            copyText += info + "\t";
+        }
+    }
+    copyText += "\n";
+
     for (const auto& idx : idxList)
     {
         auto item_model = idx.model();
-        int columnCount = m_treeModel->columnCount();
 
         for (int i = 0; i < columnCount; i++)
         {
@@ -599,7 +611,7 @@ void LogTab::CopyItemDetails(const QModelIndexList& idxList)
             {
                 auto idx_info = item_model->index(idx.row(), i, idx.parent());
                 QString info = (i == COL::Value) ?
-                    m_treeModel->GetValueFullString(idx) :
+                    m_treeModel->GetValueFullString(idx, true).replace("\t", " ") :
                     idx_info.data().toString();
 
                 if (info.length() > 0)
@@ -608,7 +620,7 @@ void LogTab::CopyItemDetails(const QModelIndexList& idxList)
                 }
                 else
                 {
-                    copyText += "N/A\t";
+                    copyText += "-\t";
                 }
             }
         }
@@ -905,8 +917,13 @@ void LogTab::UpdateStatusBar()
                 status += ", ";
             }
             status += highlightOpt.m_value;
+            if (status.size() > 100)
+            {
+                status += "...";
+                break;
+            }
         }
-        status += "}";
+        status += "}  ";
     }
 
     m_bar->SetRightLabelText(status);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -39,9 +39,7 @@ MainWindow::MainWindow()
 {
     setupUi(this);
 
-    m_statusBarLabel = new QLabel("", this);
-    statusBar()->addPermanentWidget(m_statusBarLabel);
-    m_statusBar = new StatusBar(statusBar(), m_statusBarLabel);
+    m_statusBar = new StatusBar(this);
 
     ReadSettings();
     UpdateMenuAndStatusBar();
@@ -134,7 +132,7 @@ void MainWindow::UpdateMenuAndStatusBar()
     // Status bar
     if (model == nullptr)
     {
-        m_statusBarLabel->setText("¯\\_(ツ)_/¯  ");
+        m_statusBar->SetRightLabelText("¯\\_(ツ)_/¯");
         return;
     }
 
@@ -430,6 +428,7 @@ LogTab* MainWindow::SetUpTab(EventListPtr events, bool isDirectory, QString path
         actionTail_current_tab->setChecked(true);
         on_actionTail_current_tab_triggered();
     }
+    UpdateMenuAndStatusBar();
     return logTab;
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -109,8 +109,6 @@ private:
 
     Options& m_options = Options::GetInstance();
     StatusBar * m_statusBar;
-    QLabel * m_statusBarLabel;
-    QProgressBar * m_statusBarProgressBar;
     QStringList m_recentFiles;
 
     // m_logTabs is used to store all the log tabs that MainWindow has open, by their TreeModels.

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -1,9 +1,11 @@
 #include "statusbar.h"
 
-StatusBar::StatusBar(QStatusBar* qbar, QLabel *statusLabel) :
-    m_qbar(qbar),
-    m_statusLabel(statusLabel)
+StatusBar::StatusBar(QMainWindow* parent) :
+    m_qbar(parent->statusBar()),
+    m_statusLabel(new QLabel(parent))
 {
+    m_statusLabel->setContentsMargins(0, 0, 8, 0);
+    m_qbar->addPermanentWidget(m_statusLabel);
 }
 
 void StatusBar::ShowMessage(const QString& message, int timeout)

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -6,7 +6,7 @@
 class StatusBar
 {
 public:
-    StatusBar(QStatusBar *qbar, QLabel *statusLabel);
+    StatusBar(QMainWindow* parent);
     void ShowMessage(const QString& message, int timeout);
     void SetRightLabelText(const QString& text);
 


### PR DESCRIPTION
Change the Ctrl/Cmd-C clipboard copying of items to tab-delimited single line format. And add a header row as well. Makes it easier to paste in table format.

Limit the filter text in status bar to ~100 chars, so it doesn't cover the whole bar and hide other messages.