### PR TITLE
Cache highlight colors for faster and smoother interactions

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -923,7 +923,7 @@ void LogTab::UpdateStatusBar()
                 break;
             }
         }
-        status += "}  ";
+        status += "}";
     }
 
     m_bar->SetRightLabelText(status);

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -588,10 +588,22 @@ void LogTab::ChangePrevIndex()
 void LogTab::CopyItemDetails(const QModelIndexList& idxList)
 {
     QString copyText;
+    int columnCount = m_treeModel->columnCount();
+
+    // Header row
+    for (int i = 0; i < columnCount; i++)
+    {
+        if (!(ui->treeView->isColumnHidden(i)))
+        {
+            QString info = m_treeModel->headerData(i, Qt::Horizontal).toString();
+            copyText += info + "\t";
+        }
+    }
+    copyText += "\n";
+
     for (const auto& idx : idxList)
     {
         auto item_model = idx.model();
-        int columnCount = m_treeModel->columnCount();
 
         for (int i = 0; i < columnCount; i++)
         {
@@ -599,7 +611,7 @@ void LogTab::CopyItemDetails(const QModelIndexList& idxList)
             {
                 auto idx_info = item_model->index(idx.row(), i, idx.parent());
                 QString info = (i == COL::Value) ?
-                    m_treeModel->GetValueFullString(idx) :
+                    m_treeModel->GetValueFullString(idx, true).replace("\t", " ") :
                     idx_info.data().toString();
 
                 if (info.length() > 0)
@@ -608,7 +620,7 @@ void LogTab::CopyItemDetails(const QModelIndexList& idxList)
                 }
                 else
                 {
-                    copyText += "N/A\t";
+                    copyText += "-\t";
                 }
             }
         }
@@ -905,8 +917,13 @@ void LogTab::UpdateStatusBar()
                 status += ", ";
             }
             status += highlightOpt.m_value;
+            if (status.size() > 100)
+            {
+                status += "...";
+                break;
+            }
         }
-        status += "}";
+        status += "}  ";
     }
 
     m_bar->SetRightLabelText(status);

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -832,7 +832,7 @@ void LogTab::RowHighlightSelectedType()
     newOpt.m_keys.append(COL::Key);
     newOpt.m_value = idx.model()->index(idx.row(), COL::Key, idx.parent()).data().toString();
     newOpt.m_backgroundColor = m_treeModel->m_colorLibrary.GetNextColor();
-    m_treeModel->m_highlightOpts.append(newOpt);
+    m_treeModel->AddHighlightFilter(newOpt);
     menuUpdateNeeded();
 }
 
@@ -906,12 +906,13 @@ void LogTab::HeaderItemSelected(QAction *action)
 void LogTab::UpdateStatusBar()
 {
     QString status = "";
-    if (!m_treeModel->m_highlightOpts.isEmpty())
+    if (m_treeModel->HasHighlightFilters())
     {
         status += m_treeModel->m_highlightOnlyMode ? "show only highlighted: {" : "highlighted: {";
-        for (int i=0; i< m_treeModel->m_highlightOpts.count(); i++)
+        HighlightOptions highlightOpts(m_treeModel->GetHighlightFilters());
+        for (int i=0; i< highlightOpts.count(); i++)
         {
-            SearchOpt highlightOpt = m_treeModel->m_highlightOpts[i];
+            SearchOpt highlightOpt = highlightOpts[i];
             if (i!=0)
             {
                 status += ", ";

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -39,9 +39,7 @@ MainWindow::MainWindow()
 {
     setupUi(this);
 
-    m_statusBarLabel = new QLabel("", this);
-    statusBar()->addPermanentWidget(m_statusBarLabel);
-    m_statusBar = new StatusBar(statusBar(), m_statusBarLabel);
+    m_statusBar = new StatusBar(this);
 
     ReadSettings();
     UpdateMenuAndStatusBar();
@@ -134,7 +132,7 @@ void MainWindow::UpdateMenuAndStatusBar()
     // Status bar
     if (model == nullptr)
     {
-        m_statusBarLabel->setText("¯\\_(ツ)_/¯  ");
+        m_statusBar->SetRightLabelText("¯\\_(ツ)_/¯");
         return;
     }
 
@@ -430,6 +428,7 @@ LogTab* MainWindow::SetUpTab(EventListPtr events, bool isDirectory, QString path
         actionTail_current_tab->setChecked(true);
         on_actionTail_current_tab_triggered();
     }
+    UpdateMenuAndStatusBar();
     return logTab;
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -109,8 +109,6 @@ private:
 
     Options& m_options = Options::GetInstance();
     StatusBar * m_statusBar;
-    QLabel * m_statusBarLabel;
-    QProgressBar * m_statusBarProgressBar;
     QStringList m_recentFiles;
 
     // m_logTabs is used to store all the log tabs that MainWindow has open, by their TreeModels.

--- a/src/statusbar.cpp
+++ b/src/statusbar.cpp
@@ -1,9 +1,11 @@
 #include "statusbar.h"
 
-StatusBar::StatusBar(QStatusBar* qbar, QLabel *statusLabel) :
-    m_qbar(qbar),
-    m_statusLabel(statusLabel)
+StatusBar::StatusBar(QMainWindow* parent) :
+    m_qbar(parent->statusBar()),
+    m_statusLabel(new QLabel(parent))
 {
+    m_statusLabel->setContentsMargins(0, 0, 8, 0);
+    m_qbar->addPermanentWidget(m_statusLabel);
 }
 
 void StatusBar::ShowMessage(const QString& message, int timeout)

--- a/src/statusbar.h
+++ b/src/statusbar.h
@@ -6,7 +6,7 @@
 class StatusBar
 {
 public:
-    StatusBar(QStatusBar *qbar, QLabel *statusLabel);
+    StatusBar(QMainWindow* parent);
     void ShowMessage(const QString& message, int timeout);
     void SetRightLabelText(const QString& text);
 

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -512,7 +512,6 @@ QColor TreeModel::ItemHighlightColor(const QModelIndex& idx) const
     auto cachedColor = m_highlightColorCache.find(item);
     if (cachedColor != m_highlightColorCache.end())
         return cachedColor.value();
-        //return cacheColor->second;
 
     QString valueStr;
 
@@ -539,7 +538,6 @@ QColor TreeModel::ItemHighlightColor(const QModelIndex& idx) const
 
             if (highlightOpt.HasMatch(columnStr))
             {
-//                    m_highlightColorCache[static_cast<intptr_t>(item)] = highlightOpt.m_backgroundColor;
                 m_highlightColorCache.insert(item, highlightOpt.m_backgroundColor);
                 return highlightOpt.m_backgroundColor;
             }

--- a/src/treemodel.h
+++ b/src/treemodel.h
@@ -55,7 +55,6 @@ public:
     QString GetChildValueString(const QModelIndex &index, QString key) const;
     int MergeIntoModelData(const EventList& events);
     void AddToModelData(const EventList& events);
-    bool HasFilters();
     bool ValidFindOpts();
     void ClearAllEvents();
     void ShowDeltas(qint64 delta);
@@ -64,10 +63,13 @@ public:
     QString GetValueFullString(const QModelIndex& idx, bool singleLineFormat = false) const;
     TABTYPE TabType() const;
     void SetTabType(TABTYPE type);
+    HighlightOptions GetHighlightFilters() const;
+    void SetHighlightFilters(const HighlightOptions& highlightOpts);
+    void AddHighlightFilter(const SearchOpt& filter);
+    bool HasHighlightFilters() const;
 
     bool m_highlightOnlyMode;
     bool m_liveMode;
-    HighlightOptions m_highlightOpts;
     ColorLibrary m_colorLibrary;
     SearchOpt m_findOpts;
     QList<QString> m_paths;
@@ -88,10 +90,10 @@ private:
 
     TreeItem * m_rootItem;
     qint64 m_deltaBase = 0;
-
-    // Used by ToggleHighlightOnly, as not all events might be shown.
     EventListPtr m_allEvents;
     TABTYPE m_fileType;
+    HighlightOptions m_highlightOpts;
+    mutable QHash<TreeItem*, QColor> m_highlightColorCache;
 };
 
 #endif // TREEMODEL_H


### PR DESCRIPTION
This addresses a UI perf issue encountered: using a large highlight filter set (12 filters with 5 regex) on a single large event (75K chars) is enough to cause bad UI freezes. It's addressed with:
- Cache the highlight filter colors of each top level tree item.
- Skip the filter check for non top level tree items.
- Refactor the TreeModel: add proper accessors of the highlight filters so cache will be reset as filters changed.
