### PR TITLE
Better layout for scaling and fix file checks on Windows

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -343,6 +343,14 @@ void MainWindow::on_actionClear_all_events_triggered()
     }
 }
 
+inline QString SystemCase(const QString& path)
+{
+#ifdef Q_OS_WIN32
+    return path.toLower();
+#else
+    return path;
+#endif
+}
 
 bool MainWindow::LoadLogFile(QString path)
 {
@@ -362,7 +370,7 @@ bool MainWindow::LoadLogFile(QString path)
     fileName = fi.fileName();
     filePath = fi.filePath();
 	path.replace("\\", "/");
-    if(!m_allFiles.contains(filePath))
+    if (!m_allFiles.contains(SystemCase(filePath)))
     {
         SetUpTab(events, false, path, fileName);
     }
@@ -376,7 +384,7 @@ bool MainWindow::LoadLogFile(QString path)
 void MainWindow::StartDirectoryLiveCapture(QString directoryPath, QString label)
 {
     directoryPath.replace("\\", "/");
-    if(!m_allFiles.contains(directoryPath))
+    if (!m_allFiles.contains(SystemCase(directoryPath)))
     {
         if (label.isEmpty())
         {
@@ -399,7 +407,7 @@ LogTab* MainWindow::SetUpTab(EventListPtr events, bool isDirectory, QString path
     connect(logTab, &LogTab::exportToTab, this, &MainWindow::ExportEventsToTab);
     connect(logTab, &LogTab::openFile, this, &MainWindow::LoadLogFile);
     int idx = tabWidget->addTab(logTab, label);
-    m_allFiles.append(path);
+    m_allFiles.append(SystemCase(path));
 
     auto tree = tabWidget->widget(idx)->findChild<QTreeView *>();
     TreeModel* model = GetTreeModel(tree);
@@ -544,7 +552,7 @@ void MainWindow::on_tabWidget_tabCloseRequested(int index)
     QTreeView * view = GetTreeView(index);
     TreeModel * model = GetTreeModel(view);
     LogTab * currentTab = m_logTabs[model];
-    m_allFiles.removeAll(currentTab->GetTabPath());
+    m_allFiles.removeAll(SystemCase(currentTab->GetTabPath()));
     currentTab->EndLiveCapture();
     m_logTabs.remove(model);
 

--- a/src/optionsdlg.ui
+++ b/src/optionsdlg.ui
@@ -14,7 +14,7 @@
    <string notr="true">Options</string>
   </property>
   <property name="sizeGripEnabled">
-   <bool>true</bool>
+   <bool>false</bool>
   </property>
   <property name="modal">
    <bool>true</bool>
@@ -35,7 +35,7 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <property name="bottomMargin">
-      <number>3</number>
+      <number>0</number>
      </property>
      <item>
       <widget class="QGroupBox" name="groupBox">

--- a/src/optionsdlg.ui
+++ b/src/optionsdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>502</width>
-    <height>485</height>
+    <height>486</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -34,6 +34,9 @@
    </property>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="bottomMargin">
+      <number>3</number>
+     </property>
      <item>
       <widget class="QGroupBox" name="groupBox">
        <property name="title">

--- a/src/savefilterdialog.cpp
+++ b/src/savefilterdialog.cpp
@@ -17,6 +17,7 @@ SaveFilterDialog::SaveFilterDialog(QWidget *parent, const HighlightOptions& filt
 {
     ui->setupUi(this);
     ui->lineEdit->setFocus();
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 SaveFilterDialog::~SaveFilterDialog()

--- a/src/savefilterdialog.cpp
+++ b/src/savefilterdialog.cpp
@@ -15,9 +15,9 @@ SaveFilterDialog::SaveFilterDialog(QWidget *parent, const HighlightOptions& filt
     ui(new Ui::SaveFilterDialog),
     m_filters(filters)
 {
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     ui->setupUi(this);
     ui->lineEdit->setFocus();
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 SaveFilterDialog::~SaveFilterDialog()

--- a/src/savefilterdialog.ui
+++ b/src/savefilterdialog.ui
@@ -29,13 +29,13 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Save filters as</string>
+   <string>Save Filters</string>
   </property>
   <widget class="QDialogButtonBox" name="buttonBox">
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>90</y>
+     <y>80</y>
      <width>291</width>
      <height>32</height>
     </rect>
@@ -51,7 +51,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>50</y>
+     <y>40</y>
      <width>291</width>
      <height>21</height>
     </rect>
@@ -75,8 +75,8 @@
    <property name="font">
     <font>
      <pointsize>10</pointsize>
-     <weight>75</weight>
-     <bold>true</bold>
+     <weight>50</weight>
+     <bold>false</bold>
     </font>
    </property>
    <property name="text">

--- a/src/savefilterdialog.ui
+++ b/src/savefilterdialog.ui
@@ -72,13 +72,6 @@
      <height>31</height>
     </rect>
    </property>
-   <property name="font">
-    <font>
-     <pointsize>10</pointsize>
-     <weight>50</weight>
-     <bold>false</bold>
-    </font>
-   </property>
    <property name="text">
     <string>Highlight filters collection name:</string>
    </property>

--- a/src/savefilterdialog.ui
+++ b/src/savefilterdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>330</width>
-    <height>130</height>
+    <height>126</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -16,8 +16,20 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>330</width>
+    <height>126</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>330</width>
+    <height>126</height>
+   </size>
+  </property>
   <property name="windowTitle">
-   <string>Name the filter collection</string>
+   <string>Save filters as</string>
   </property>
   <widget class="QDialogButtonBox" name="buttonBox">
    <property name="geometry">
@@ -39,10 +51,13 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>60</y>
+     <y>50</y>
      <width>291</width>
-     <height>20</height>
+     <height>21</height>
     </rect>
+   </property>
+   <property name="toolTip">
+    <string>Use alphanumeric characters, underscores, dashes, periods, and spaces.</string>
    </property>
    <property name="maxLength">
     <number>100</number>
@@ -53,8 +68,8 @@
     <rect>
      <x>20</x>
      <y>10</y>
-     <width>321</width>
-     <height>16</height>
+     <width>291</width>
+     <height>31</height>
     </rect>
    </property>
    <property name="font">
@@ -65,20 +80,10 @@
     </font>
    </property>
    <property name="text">
-    <string>Give a name to the Highlight Filters Collection</string>
+    <string>Highlight filters collection name:</string>
    </property>
-  </widget>
-  <widget class="QLabel" name="label_2">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>40</y>
-     <width>241</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Use alphanumeric characters</string>
+   <property name="textFormat">
+    <enum>Qt::AutoText</enum>
    </property>
   </widget>
  </widget>

--- a/src/valuedlg.cpp
+++ b/src/valuedlg.cpp
@@ -23,6 +23,8 @@ ValueDlg::ValueDlg(QWidget *parent) :
     ui(new Ui::ValueDlg)
 {
     ui->setupUi(this);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
     // Set a monospaced font.
     const QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     ui->textEdit->setFont(fixedFont);


### PR DESCRIPTION
* Fix for bug: same file can be opened in multiple tabs on Windows.
Bug: the same file or directory can be opened in separate tabs on Windows, when the paths are specified in different casing.
Fix: Always use lower casing on Windows to maintain list of opened paths and to compare.

* UI tweaks for better layout in 125-150% scaling on Windows
The main label on Save Filters dialog was cut off when displayed with 125-150% scaling on Windows. Simplify the title and labels and enlarge some sizes to address this.
For scaling more than 150%, it would require setting dpiawareness=0 at command line or conf file.

