### PR TITLE
Persist last used font size and windows state of value dialog, tree view and main window

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -29,8 +29,6 @@ LogTab::~LogTab()
 
 void LogTab::InitTreeView(const EventListPtr events)
 {
-    QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-    ui->treeView->setFont(fixedFont);
     ui->treeView->setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);
 
     QStringList headers = QString("ID;File;Time;Elapsed;PID;TID;Severity;Request;Session;Site;User;Key;Value").split(";");
@@ -43,7 +41,6 @@ void LogTab::InitTreeView(const EventListPtr events)
 
     bool hasNoKey = (events->size() > 0 && events->at(0)["k"].toString().isEmpty());
 
-    ui->treeView->SetAutoResizeColumns({COL::Time, COL::Elapsed});
     SetColumn(COL::ID, 80, false);
     SetColumn(COL::File, 110, true);
     SetColumn(COL::Time, 190, hasNoKey);
@@ -56,6 +53,7 @@ void LogTab::InitTreeView(const EventListPtr events)
     SetColumn(COL::Site, 180, true);
     SetColumn(COL::User, 30, true);
     SetColumn(COL::Key, 120, hasNoKey);
+    ui->treeView->SetAutoResizeColumns({COL::Time, COL::Elapsed});
 
     ui->treeView->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->treeView->header()->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -337,6 +335,7 @@ void LogTab::ReadDirectoryFiles()
 
     if (newEvents.count() > 0)
     {
+        bool firstEntries = (m_treeModel->rowCount() == 0);
         int startRow = m_treeModel->MergeIntoModelData(newEvents);
         newEvents.clear();
 
@@ -352,6 +351,10 @@ void LogTab::ReadDirectoryFiles()
 
         TrimEventCount();
         UpdateModelView();
+        if (firstEntries)
+        {
+            ui->treeView->ResizeColumns();
+        }
     }
 }
 

--- a/src/valuedlg.h
+++ b/src/valuedlg.h
@@ -1,11 +1,9 @@
-#ifndef VALUEDLG_H
-#define VALUEDLG_H
-
-#include "treemodel.h"
+#pragma once
 
 #include <QDialog>
-#include <QNetworkReply>
-#include <QWebEngineView>
+class QNetworkReply;
+class QSettings;
+class QWebEngineView;
 
 namespace Ui {
 class ValueDlg;
@@ -21,8 +19,14 @@ public:
     void SetText(QString value, bool sqlHighlight);
     void SetQuery(QString queryXML);
 
+    static void WriteSettings(QSettings& settings);
+    static void ReadSettings(QSettings& settings);
+
     QString m_id;
     QString m_key;
+
+protected:
+    void reject() override;
 
 private slots:
     void on_visualizeButton_clicked();
@@ -30,6 +34,7 @@ private slots:
     void on_prevButton_clicked();
     void on_nextButton_clicked();
     void on_uploadFinished(QNetworkReply*);
+    void on_loadFinished(bool);
     void on_zoomIn();
     void on_zoomOut();
 
@@ -43,7 +48,6 @@ private:
     QUrl GetVisualizeURL(QNetworkReply * const reply);
     void UploadQuery();
     void VisualizeQuery();
-    void on_loadFinished(bool);
 
     Ui::ValueDlg *ui;
     QString m_queryXML;
@@ -51,6 +55,7 @@ private:
     QString m_visualizationServiceURL;
     QWebEngineView *m_view;
     bool m_reload;
-};
 
-#endif // VALUEDLG_H
+    static QByteArray sm_savedGeometry;
+    static qreal sm_savedFontPointSize;
+};

--- a/src/zoomabletreeview.cpp
+++ b/src/zoomabletreeview.cpp
@@ -2,11 +2,19 @@
 
 #include <QApplication>
 #include <QDebug>
+#include <QFontDatabase>
+#include <QSettings>
 #include <QWheelEvent>
+
+qreal ZoomableTreeView::sm_savedFontPointSize { 0 };
 
 ZoomableTreeView::ZoomableTreeView(QWidget *parent)
     :QTreeView(parent)
-{}
+{
+    QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    fixedFont.setPointSizeF(sm_savedFontPointSize);
+    this->setFont(fixedFont);
+}
 
 void ZoomableTreeView::SetAutoResizeColumns(const std::vector<int>& columns)
 {
@@ -28,15 +36,12 @@ void ZoomableTreeView::ResizeFont(int delta)
 {
     QFont font = this->font();
 
-    // Keep the original font size here, as it can't be determined correctly in constructor.
-    if (m_defaultFontSize < 0)
-        m_defaultFontSize = font.pointSize();
-
     // Set the font size, make sure it fits in a reasonable range
     int pointSize;
     if (delta == 0)
     {
-        pointSize = m_defaultFontSize;
+        QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+        pointSize = font.pointSize();
     }
     else
     {
@@ -45,6 +50,7 @@ void ZoomableTreeView::ResizeFont(int delta)
     }
     font.setPointSize(pointSize);
     this->setFont(font);
+    sm_savedFontPointSize = pointSize;
 
     ResizeColumns();
 }
@@ -84,4 +90,18 @@ void ZoomableTreeView::keyPressEvent(QKeyEvent* event)
     {
         QTreeView::keyPressEvent(event);
     }
+}
+
+void ZoomableTreeView::WriteSettings(QSettings& settings)
+{
+    settings.beginGroup("TreeView");
+    settings.setValue("fontPointSize", sm_savedFontPointSize);
+    settings.endGroup();
+}
+
+void ZoomableTreeView::ReadSettings(QSettings& settings)
+{
+    settings.beginGroup("TreeView");
+    sm_savedFontPointSize = settings.value("fontPointSize").toReal();
+    settings.endGroup();
 }

--- a/src/zoomabletreeview.h
+++ b/src/zoomabletreeview.h
@@ -1,8 +1,7 @@
-#ifndef ZOOMABLETREEVIEW_H
-#define ZOOMABLETREEVIEW_H
+#pragma once
 
 #include <QTreeView>
-#include <QWidget>
+class QSettings;
 
 class ZoomableTreeView: public QTreeView
 {
@@ -11,6 +10,10 @@ class ZoomableTreeView: public QTreeView
 public:
     ZoomableTreeView(QWidget *parent);
     void SetAutoResizeColumns(const std::vector<int>& columns);
+    void ResizeColumns();
+
+    static void WriteSettings(QSettings& settings);
+    static void ReadSettings(QSettings& settings);
 
 protected:
     void wheelEvent(QWheelEvent *) override;
@@ -18,13 +21,11 @@ protected:
 
 private:
     void ResizeFont(int delta);
-    void ResizeColumns();
 
-    int m_defaultFontSize = -1;
     std::vector<int> m_autoResizedColumns;
+
+    static qreal sm_savedFontPointSize;
 
     const int MIN_FONT_SIZE = 7;
     const int MAX_FONT_SIZE = 24;
 };
-
-#endif // ZOOMABLETREEVIEW_H


### PR DESCRIPTION
Value dialog: Keep last used font size and windows geometry (position +
size).

LogTab tree view: Keep last used font size; And auto resize time and
elapsed columns for visibility; Similar to browser model, new size
applies to current and future tabs, but not other existing tabs.

Main windows: now save and restore windows state (maximized/normal)
together with geometry. Remove duplicated WriteSettings call.

To prevent interfering among multiple instances of TLV, settings are
maintained in static variables, and only read/write upon app starts and
exits.