### PR TITLE
Travis-CI and AppVeyor configuration files and badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: cpp
+dist: trusty
+
+os:
+- linux
+#- osx
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - freeglut3-dev
+    - gcc-5
+    - g++-5
+
+env:
+- BUILDDIR=build-release
+
+before_install:
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo script/before_install_linux.sh; export QTDIR=/opt/qt57; export QMAKECC=gcc-5; export QMAKECXX=g++-5; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then script/before_install_osx.sh; export QTDIR=/usr/local/Cellar/qt57; export QMAKECC=clang; export QMAKECXX=clang++; fi
+
+script:
+- echo $QTDIR
+- mkdir $BUILDDIR
+- cd $BUILDDIR
+- source $QTDIR/bin/qt57-env.sh
+- $QTDIR/bin/qmake -spec linux-g++-64 QMAKE_CC=$QMAKECC QMAKE_CXX=$QMAKECXX -Wall ../src/tableau-log-viewer.pro
+- make

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,6 +32,41 @@ macdeployqt tlv.app
 open tlv.app
 ```
 
+## Building on Linux
+
+### Install a recent GCC with C++14 support
+
+```bash
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt-get update -y
+sudo apt-get install -y build-essential gcc-5 g++-5
+```
+
+### Install Qt 5.7 components
+
+```bash
+sudo add-apt-repository -y ppa:beineri/opt-qt57-trusty
+sudo apt-get update -y
+sudo apt-get install -y qt57base qt57declarative qt57quickcontrols qt57graphicaleffects qt57tools qt57svg qt57webengine
+```
+
+### Install OpenGL components
+
+```bash
+sudo apt-get install -y freeglut3-dev
+```
+
+### Build
+
+Assumes that Qt 5.7 packages are installed under `/opt/qt57`
+
+```bash
+source /opt/qt57/bin/qt57-env.sh
+mkdir -p build-release
+cd build-release
+$QTHOME/bin/qmake -spec linux-g++-64 QMAKE_CC=gcc-5 QMAKE_CXX=g++-5 -Wall ../src/tableau-log-viewer.pro
+make
+```
 
 ## Building on Windows (using command line)
 The following instructions use Qt 5.6 and the Visual Studio 2013 compiler (mscv2013) to compile a 64-bit binary.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tableau Log Viewer
 
+[![Travis-CI](https://img.shields.io/travis/tableau/tableau-log-viewer/dev.svg?label=Linux%20build)](https://travis-ci.org/tableau/tableau-log-viewer) [![AppVeyor](https://img.shields.io/appveyor/ci/tableau/tableau-log-viewer/dev.svg?label=Windows%20build)](https://ci.appveyor.com/project/tableau/tableau-log-viewer/branch/dev)
+
 Tableau Log Viewer is cross-platform tool with a simple interface that has a single purpose of making it easy to quickly glance over Tableau log files.
 
 ![TLV Screenshot](https://cloud.githubusercontent.com/assets/1087437/19377630/b1ca0d56-919c-11e6-9c01-200697c37194.png "TLV running on Windows 10")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+install:
+- set QTHOME=C:\Qt\5.7\msvc2013_64
+- set BUILDDIR=build-release
+- set PATH=%QTHOME%\bin;%PATH%
+build_script:
+- '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64'
+- mkdir %BUILDDIR%
+- cd /d %BUILDDIR%
+- qmake.exe -spec win32-msvc2013 CONFIG+=x86_64 -Wall ..\src\tableau-log-viewer.pro
+- nmake

--- a/script/before_install_linux.sh
+++ b/script/before_install_linux.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+add-apt-repository -y ppa:beineri/opt-qt57-trusty
+apt-get update -y
+apt-get install -y \
+  qt57declarative \
+  qt57graphicaleffects \
+  qt57quickcontrols \
+  qt57svg \
+  qt57tools \
+  qt57webengine

--- a/script/before_install_osx.sh
+++ b/script/before_install_osx.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+brew install qt5 --with-qtwebkit


### PR DESCRIPTION
* Add badges to README.md
* Add build instructions for Linux to INSTALL.md
* Note that the OS X build on Travis-CI is currently disabled as building Qt from source takes too long

To enable this, someone will need to enable Travis-CI and AppVeyor builds on this repo (at https://travis-ci.org/ and https://www.appveyor.com/ respectively).

In order to set up an effective CI for OS X, we'd need to build Qt 5.7 in another repo and publish the binary packages to GitHub and then pull these down to Travis-CI each build. Otherwise the OS X build takes several hours.

This change adds badges for the `dev` branch which is the intended branch for this change. I've also rebased properly on top of `dev`!