### PR TITLE
Option to set text size limit for syntax highlighting in value dialog

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -507,7 +507,11 @@ void LogTab::ShowDetails(const QModelIndex& idx, ValueDlg& valueDlg)
     valueDlg.m_key = idx_key.data().toString();
 
     valueDlg.setWindowTitle(QString("ID: %1 - Key: %2").arg(valueDlg.m_id, valueDlg.m_key));
-    bool syntaxHighlight = (!valueDlg.m_key.isEmpty() && valueDlg.m_key != "msg");
+    int syntaxHighlightLimit = Options::GetInstance().getSyntaxHighlightLimit();
+    bool syntaxHighlight = (valueDlg.m_key != "msg" &&
+                            !valueDlg.m_key.isEmpty() &&
+                            syntaxHighlightLimit &&
+                            value.size() <= syntaxHighlightLimit);
     valueDlg.SetText(value, syntaxHighlight);
     valueDlg.SetQuery(QString(""));
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,9 +1,11 @@
 #include "options.h"
+#include "pathhelper.h"
 
 #include <QByteArray>
 #include <QDir>
 #include <QFile>
 #include <QJsonDocument>
+#include <QSettings>
 #include <QSysInfo>
 
 void Options::ReadSettings()
@@ -22,6 +24,7 @@ void Options::ReadSettings()
     m_futureTabsUnderLive = settings.value("enableLiveCapture").toBool();
     m_defaultFilterName = settings.value("defaultHighlightFilter", "None").toString();
     m_captureAllTextFiles = settings.value("liveCaptureAllTextFiles", true).toBool();
+    m_syntaxHighlightLimit = settings.value("syntaxHighlightLimit", 15000).toInt();
 
     settings.endGroup();
 
@@ -93,4 +96,9 @@ void Options::LoadHighlightFilter(const QString& filterName)
     QJsonDocument filtersDoc(QJsonDocument::fromJson(filterData));
     m_defaultHighlightOpts.FromJson(filtersDoc.array());
     // Currently this does not apply to already open tabs, but I think that's fine.
+}
+
+int Options::getSyntaxHighlightLimit() const
+{
+    return m_syntaxHighlightLimit;
 }

--- a/src/options.h
+++ b/src/options.h
@@ -1,20 +1,15 @@
-#ifndef OPTIONS_H
-#define OPTIONS_H
+#pragma once
 
 #include "highlightoptions.h"
-#include "pathhelper.h"
 
 #include <QBitArray>
-#include <QSettings>
-#include <QString>
-#include <QStringList>
 
 class Options
 {
 private:
     Options(){ ReadSettings(); }
-    Options(const Options&);
-    Options& operator= (const Options&);
+    Options(const Options&) = delete;
+    Options& operator= (const Options&) = delete;
 
     QStringList m_skippedText;
     QBitArray m_skippedState;
@@ -25,15 +20,16 @@ private:
     bool m_captureAllTextFiles;
     QString m_defaultFilterName;
     HighlightOptions m_defaultHighlightOpts;
+    int m_syntaxHighlightLimit;
 
 public:
     static Options& GetInstance()
     {
-        static Options sm_options;
-        return sm_options;
+        static Options options;
+        return options;
     }
-    static void DeleteInstance();
     void ReadSettings();
+    void LoadHighlightFilter(const QString& filterName);
 
     QStringList getSkippedText();
     QBitArray getSkippedState();
@@ -44,7 +40,5 @@ public:
     bool getCaptureAllTextFiles();
     QString getDefaultFilterName();
     HighlightOptions getDefaultHighlightOpts();
-    void LoadHighlightFilter(const QString& filterName);
+    int getSyntaxHighlightLimit() const;
 };
-
-#endif // OPTIONS_H

--- a/src/optionsdlg.cpp
+++ b/src/optionsdlg.cpp
@@ -40,6 +40,7 @@ void OptionsDlg::WriteSettings()
     auto liveEnable = ui->startFutureLiveCapture->isChecked();
     bool captureAllTextFiles = ui->captureAllTextFiles->isChecked();
     auto currFilter = ui->defaultHighlightComboBox->currentText();
+    int syntaxHighlightLimit = ui->syntaxHighlightLimitSpinBox->value();
 
     QString iniPath = PathHelper::GetConfigIniPath();
     QSettings settings(iniPath, QSettings::IniFormat);
@@ -52,6 +53,7 @@ void OptionsDlg::WriteSettings()
     settings.setValue("enableLiveCapture", liveEnable);
     settings.setValue("liveCaptureAllTextFiles", captureAllTextFiles);
     settings.setValue("defaultHighlightFilter", currFilter);
+    settings.setValue("syntaxHighlightLimit", syntaxHighlightLimit);
     settings.endGroup();
 
     Options::GetInstance().ReadSettings();
@@ -68,6 +70,7 @@ void OptionsDlg::ReadSettings()
     auto liveEnable = options.getFutureTabsUnderLive();
     bool captureAllTextFiles = options.getCaptureAllTextFiles();
     auto defaultHighlightFilter = options.getDefaultFilterName();
+    int syntaxHighlightLimit = options.getSyntaxHighlightLimit();
 
     for (int i = 0; i < skippedText.length(); i++)
     {
@@ -82,6 +85,7 @@ void OptionsDlg::ReadSettings()
     ui->diffToolPath->setText(diffPath);
     ui->startFutureLiveCapture->setChecked(liveEnable);
     ui->captureAllTextFiles->setChecked(captureAllTextFiles);
+    ui->syntaxHighlightLimitSpinBox->setValue(syntaxHighlightLimit);
 
     // load all saved filters for default filters
     ui->defaultHighlightComboBox->addItem(QString("None"));

--- a/src/optionsdlg.ui
+++ b/src/optionsdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>502</width>
-    <height>486</height>
+    <height>529</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -198,6 +198,36 @@
            <string>Include all text files in directory live capture</string>
           </property>
          </widget>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="syntaxHighlightLimitLabel">
+            <property name="text">
+             <string>Character limit for syntax highlighting in the value dialog</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="syntaxHighlightLimitSpinBox">
+            <property name="toolTip">
+             <string>Set a smaller character limit for syntax highlighting, if it takes too long to open an event in value dialog.</string>
+            </property>
+            <property name="showGroupSeparator" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="maximum">
+             <number>1000000</number>
+            </property>
+            <property name="singleStep">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>10000</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
While syntax highlighting (coloring) in value dialog is very useful, it
can be slow on large text.
"Accidentally" opening a 350K long qp-batch-summary event could cause a
more than 1 minute wait/hang.
Worse, users have no idea how big the event is before opening it.
Now add an option to set the text size limit for syntax highlighting,
and default it to 15,000. So one could adjust it based on the computing
power and one's patience.