### PR TITLE
Show tooltips in tree view

### DIFF
--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -96,11 +96,13 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const
             if (col == COL::Value)
             {
                 const int ToolTipLimit = 500;
+                const int ToolTipTailSize = 50;
                 QString tip = GetValueFullString(index);
                 if (tip.size() > ToolTipLimit)
                 {
-                    tip.truncate(ToolTipLimit);
-                    tip += "...";
+                    QString tail = tip.right(ToolTipTailSize);
+                    tip.truncate(ToolTipLimit - ToolTipTailSize);
+                    tip += "\n...\n" + tail;
                 }
                 return tip;
             }

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -91,6 +91,26 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const
             return item->Data(col);
             break;
         }
+        case Qt::ToolTipRole:
+        {
+            if (col == COL::Value)
+            {
+                const int ToolTipLimit = 500;
+                QString tip = GetValueFullString(index);
+                if (tip.size() > ToolTipLimit)
+                {
+                    tip.truncate(ToolTipLimit);
+                    tip += "...";
+                }
+                return tip;
+            }
+            else
+            {
+                TreeItem* item = GetItem(index);
+                return item->Data(col);
+            }
+            break;
+        }
     }
     return QVariant();
 }


### PR DESCRIPTION
Show tooltips in the log tree view, including values with linefeed upto
500 characters.