### PR TITLE
Copy items as a HTML table

### DIFF
--- a/src/logtab.h
+++ b/src/logtab.h
@@ -39,7 +39,8 @@ private:
     void InitHeaderMenu();
     void SetColumn(int column, int width, bool isHidden);
     void ShowItemDetails(const QModelIndex&);
-    void CopyItemDetails(const QModelIndexList& idxList);
+    void CopyItemDetails(bool textOnly = false) const;
+    void CopyItemDetailsAsText() const;
     void RowFindPrev();
     void RowFindNext();
     void RowFindImpl(int offset);
@@ -64,6 +65,8 @@ private:
     ValueDlg *m_valueDlg;
     std::vector<std::unique_ptr<QTemporaryFile>> m_tempFiles;
     QAction *m_exportToTabAction;
+    QAction *m_copyItemsHtmlAction;
+    QAction *m_copyItemsTextAction;
     int m_openFileMenuIdx;
     int m_eventIndex;
     QFile m_logFile;


### PR DESCRIPTION
Change the copy to clipboard function to include HTML table format, in
addition to the tab separated text format.
This makes it easier to copy and paste items for bug reporting.
Most apps, including Outlook, Excel and Chrome, have options to paste it
as HTML (default) and as text.
But for more versatility, also add context menu to allow copy as text
only.
Both types of copy can be pasted to Tableau directly.

Binaries available at internal installation share.