### PR TITLE
Context menu on tab bar to copy path and open folder

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -1013,12 +1013,14 @@ QString LogTab::GetDebugInfo() const
 
 void LogTab::CopyFullPath()
 {
+    QString path = QDir::toNativeSeparators(GetTabPath());
     QClipboard* clipboard = QApplication::clipboard();
     clipboard->setText(path);
 }
 
 void LogTab::OpenContainingDirectory()
 {
+    QString path = GetTabPath();
     if (m_treeModel->TabType() == TABTYPE::SingleFile)
     {
         QFileInfo fi(path);

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -1018,7 +1018,7 @@ void LogTab::CopyFullPath()
     clipboard->setText(path);
 }
 
-void LogTab::OpenContainingDirectory()
+void LogTab::ShowInFolder()
 {
     QString path = GetTabPath();
     if (m_treeModel->TabType() == TABTYPE::SingleFile)

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -908,7 +908,7 @@ void LogTab::InitHeaderMenu()
         QAction *action = new QAction(hdata.toString(), m_headerMenu);
         action->setCheckable(true);
         // Make some columns 'unhidable'
-        if (i == COL::ID || i == COL::Value)
+        if (i == COL::Value)
         {
             action->setEnabled(false);
         }
@@ -1009,4 +1009,20 @@ QString LogTab::GetDebugInfo() const
     }
 
     return QString("Type: %1\nPath: %2\n\n%3").arg(tabType).arg(m_tabPath).arg(extra);
+}
+
+void LogTab::CopyFullPath()
+{
+    QClipboard* clipboard = QApplication::clipboard();
+    clipboard->setText(path);
+}
+
+void LogTab::OpenContainingDirectory()
+{
+    if (m_treeModel->TabType() == TABTYPE::SingleFile)
+    {
+        QFileInfo fi(path);
+        path = fi.path();
+    }
+    QDesktopServices::openUrl(QUrl::fromLocalFile(path));
 }

--- a/src/logtab.h
+++ b/src/logtab.h
@@ -27,6 +27,8 @@ public:
     QString GetTabPath() const;
     void SetTabPath(const QString& path);
     void UpdateStatusBar();
+    void CopyFullPath();
+    void OpenContainingDirectory();
 
 private:
     void keyPressEvent(QKeyEvent *event) override;

--- a/src/logtab.h
+++ b/src/logtab.h
@@ -28,7 +28,7 @@ public:
     void SetTabPath(const QString& path);
     void UpdateStatusBar();
     void CopyFullPath();
-    void OpenContainingDirectory();
+    void ShowInFolder();
 
 private:
     void keyPressEvent(QKeyEvent *event) override;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -54,6 +54,8 @@ MainWindow::MainWindow()
     menuHelp->addAction(aboutVersionAction);
 
     connect(Ui_MainWindow::menuRecent_files, SIGNAL(triggered(QAction*)), this, SLOT(Recent_files_triggered(QAction*)));
+
+    tabWidget->tabBar()->installEventFilter(this);
 }
 
 MainWindow::~MainWindow()
@@ -1074,3 +1076,42 @@ void MainWindow::RefilterTreeView()
     model->layoutChanged();
     view->scrollTo(previousIdx, QAbstractItemView::PositionAtCenter);
 }
+
+bool MainWindow::eventFilter(QObject* obj, QEvent* event)
+{
+    if (obj == tabWidget->tabBar() &&
+        event->type() == QEvent::MouseButtonPress)
+    {
+        auto mouseEvent = static_cast<QMouseEvent *>(event);
+        int idx = tabWidget->tabBar()->tabAt(mouseEvent->pos());
+
+        if (mouseEvent->button() == Qt::MidButton)
+        {
+            on_tabWidget_tabCloseRequested(idx);
+            return true;
+        }
+        else if (mouseEvent->button() == Qt::RightButton)
+        {
+            TreeModel* model = GetTreeModel(GetTreeView(idx));
+            if (!model || model->TabType() == TABTYPE::ExportedEvents)
+                return true;
+
+            LogTab* logTab = m_logTabs[model];
+
+            QAction* actionCopyFullPath = new QAction("Copy full path", this);
+            connect(actionCopyFullPath, &QAction::triggered, logTab, &LogTab::CopyFullPath);
+
+            QAction* actionOpenDirectory = new QAction("Open containing directory", this);
+            connect(actionOpenDirectory, &QAction::triggered, logTab, &LogTab::OpenContainingDirectory);
+
+            auto tabBarMenu = new QMenu(this);
+            tabBarMenu->addAction(actionCopyFullPath);
+            tabBarMenu->addAction(actionOpenDirectory);
+            tabBarMenu->popup(mouseEvent->globalPos());
+            return true;
+        }
+    }
+
+    return QMainWindow::eventFilter(obj, event);
+}
+

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1098,16 +1098,16 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
 
             LogTab* logTab = m_logTabs[model];
 
-            QAction* actionCopyFullPath = new QAction("Copy full path", this);
-            connect(actionCopyFullPath, &QAction::triggered, logTab, &LogTab::CopyFullPath);
+            QAction actionCopyFullPath("Copy full path", this);
+            connect(&actionCopyFullPath, &QAction::triggered, logTab, &LogTab::CopyFullPath);
 
-            QAction* actionOpenDirectory = new QAction("Show in folder", this);
-            connect(actionOpenDirectory, &QAction::triggered, logTab, &LogTab::ShowInFolder);
+            QAction actionOpenDirectory("Show in folder", this);
+            connect(&actionOpenDirectory, &QAction::triggered, logTab, &LogTab::ShowInFolder);
 
-            auto tabBarMenu = new QMenu(this);
-            tabBarMenu->addAction(actionCopyFullPath);
-            tabBarMenu->addAction(actionOpenDirectory);
-            tabBarMenu->popup(mouseEvent->globalPos());
+            QMenu tabBarMenu(this);
+            tabBarMenu.addAction(&actionCopyFullPath);
+            tabBarMenu.addAction(&actionOpenDirectory);
+            tabBarMenu.exec(mouseEvent->globalPos());
             return true;
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1101,8 +1101,8 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
             QAction* actionCopyFullPath = new QAction("Copy full path", this);
             connect(actionCopyFullPath, &QAction::triggered, logTab, &LogTab::CopyFullPath);
 
-            QAction* actionOpenDirectory = new QAction("Open containing directory", this);
-            connect(actionOpenDirectory, &QAction::triggered, logTab, &LogTab::OpenContainingDirectory);
+            QAction* actionOpenDirectory = new QAction("Show in folder", this);
+            connect(actionOpenDirectory, &QAction::triggered, logTab, &LogTab::ShowInFolder);
 
             auto tabBarMenu = new QMenu(this);
             tabBarMenu->addAction(actionCopyFullPath);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -33,6 +33,7 @@ protected:
     void dragEnterEvent(QDragEnterEvent *event);
     void dropEvent(QDropEvent *event);
     void keyPressEvent(QKeyEvent * k);
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
 private slots:
     void Recent_files_triggered(QAction * action);


### PR DESCRIPTION
Add mouse event handler on tab bar for:
- Middle click to close the tab.
- Right click for context menu to copy full path and to show containing folder in explorer/finder.

Tested on Windows and MacOS.