### PR TITLE
Starting TLV with live capture on

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,6 @@
 #include <QApplication>
 
 #include "mainwindow.h"
-#include <QVector>
 
 int main(int argc, char *argv[])
 {
@@ -13,9 +12,7 @@ int main(int argc, char *argv[])
     app.setApplicationVersion(APP_VERSION);
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
 
-    QStringList args = app.arguments();
-
-    std::unique_ptr<MainWindow> mainWin = std::make_unique<MainWindow>(args);
+    std::unique_ptr<MainWindow> mainWin = std::make_unique<MainWindow>(app.arguments());
     mainWin->show();
     return app.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <QApplication>
 
 #include "mainwindow.h"
+#include <QVector>
 
 int main(int argc, char *argv[])
 {
@@ -12,7 +13,9 @@ int main(int argc, char *argv[])
     app.setApplicationVersion(APP_VERSION);
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
 
-    std::unique_ptr<MainWindow> mainWin = std::make_unique<MainWindow>();
+    QStringList args = app.arguments();
+
+    std::unique_ptr<MainWindow> mainWin = std::make_unique<MainWindow>(args);
     mainWin->show();
     return app.exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -34,7 +34,7 @@
 #include <QTime>
 #include <QTreeView>
 
-MainWindow::MainWindow()
+MainWindow::MainWindow(const QStringList& args)
 {
     setupUi(this);
 
@@ -56,6 +56,20 @@ MainWindow::MainWindow()
     connect(Ui_MainWindow::menuRecent_files, SIGNAL(triggered(QAction*)), this, SLOT(Recent_files_triggered(QAction*)));
 
     tabWidget->tabBar()->installEventFilter(this);
+
+    // Parse command line live captures
+    for(int i=1; i<args.size(); i++)
+    {
+        QString livecap = args[i];
+        if(livecap == "LiveLog" || livecap == "-LiveLog")
+            on_actionOpen_log_txt_triggered();
+        else if(livecap == "LiveBetaLog" || livecap == "-LiveBetaLog")
+            on_actionOpen_beta_log_txt_triggered();
+        else if(livecap == "LiveDir" || livecap == "-LiveDir")
+            on_actionLog_directory_triggered();
+        else if(livecap == "LiveBetaDir" || livecap == "-LiveBetaDir")
+            on_actionBeta_log_directory_triggered();
+    }
 }
 
 MainWindow::~MainWindow()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -25,14 +25,14 @@ class MainWindow : public QMainWindow, private Ui::MainWindow
     Q_OBJECT
 
 public:
-    MainWindow();
+    MainWindow(const QStringList& args);
     ~MainWindow();
 
 protected:
-    void closeEvent(QCloseEvent *event);
-    void dragEnterEvent(QDragEnterEvent *event);
-    void dropEvent(QDropEvent *event);
-    void keyPressEvent(QKeyEvent * k);
+    void closeEvent(QCloseEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
+    void keyPressEvent(QKeyEvent * k) override;
     bool eventFilter(QObject *watched, QEvent *event) override;
 
 private slots:


### PR DESCRIPTION
Added 4 flags to TLV, and the ability to parse them

1. LiveLog: Live captures log
2. LiveBetaLog: Live captures beta log
3. LiveDir: Live captures log directory
4. LiveBetaDir: Live captures beta log directory

You can use 0-4 of these when starting TLV to start live capturing 0-4 new tabs automatically.

Note: Also added override to some MainWindow functions, as compiler was complaining slightly.

