### PR TITLE
Add gray background theme option.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -65,7 +65,12 @@ MainWindow::~MainWindow()
 void MainWindow::Recent_files_triggered(QAction * action)
 {
     QString path = action->text();
-    if (!LoadLogFile(path))
+    QFileInfo fi(path);
+    if (fi.isDir())
+    {
+        StartDirectoryLiveCapture(path, "");
+    }
+    else if (!LoadLogFile(path))
     {
         RemoveRecentFile(path);
         Ui_MainWindow::menuRecent_files->removeAction(action);
@@ -153,6 +158,7 @@ void MainWindow::WriteSettings()
     settings.setValue("geometry", saveGeometry());
     settings.setValue("windowState", saveState());
     settings.setValue("recentFiles", m_recentFiles);
+    settings.setValue("lastOpenFolder", m_lastOpenFolder);
     settings.endGroup();
 
     ValueDlg::WriteSettings(settings);
@@ -179,6 +185,7 @@ void MainWindow::ReadSettings()
         settings.remove("pos");
     }
     m_recentFiles = settings.value("recentFiles", QStringList()).toStringList();
+    m_lastOpenFolder = settings.value("lastOpenFolder", QString()).toString();
     settings.endGroup();
 
     //Load Options variables from config file
@@ -274,7 +281,6 @@ void MainWindow::AddRecentFile(const QString& path)
     //Otherwise add it to the top of the list
     else if(path != "")
     {
-        if(m_recentFiles.size() > 9)
         {
             m_recentFiles.removeLast();
         }
@@ -435,7 +441,7 @@ LogTab* MainWindow::SetUpTab(EventListPtr events, bool isDirectory, QString path
     {
         model->m_paths.append(path);
         model->SetTabType(TABTYPE::SingleFile);
-        AddRecentFile(path);
+    AddRecentFile(path);
     }
     else
     {
@@ -488,20 +494,11 @@ void MainWindow::on_actionBeta_log_directory_triggered()
 
 void MainWindow::on_actionChoose_directory_triggered()
 {
-    // Use file path of the current tab as default directory.
-    // It works with both file and directory paths.
-    QString defaultDir;
-    TreeModel* model = GetCurrentTreeModel();
-    if (model)
-    {
-        LogTab* currentTab = m_logTabs[model];
-        defaultDir = currentTab->GetTabPath();
-    }
-
-    QString directoryPath = QFileDialog::getExistingDirectory(this, "Select directory to monitor", defaultDir);
+    QString directoryPath = QFileDialog::getExistingDirectory(this, "Select directory to monitor", m_lastOpenFolder);
     if (!directoryPath.isEmpty())
     {
         StartDirectoryLiveCapture(directoryPath, "");
+        m_lastOpenFolder = directoryPath;
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -281,6 +281,7 @@ void MainWindow::AddRecentFile(const QString& path)
     //Otherwise add it to the top of the list
     else if(path != "")
     {
+        if (m_recentFiles.size() > 14)
         {
             m_recentFiles.removeLast();
         }
@@ -441,12 +442,12 @@ LogTab* MainWindow::SetUpTab(EventListPtr events, bool isDirectory, QString path
     {
         model->m_paths.append(path);
         model->SetTabType(TABTYPE::SingleFile);
-    AddRecentFile(path);
     }
     else
     {
         model->SetTabType(TABTYPE::Directory);
     }
+    AddRecentFile(path);
     logTab->SetTabPath(path);
     actionTail_current_tab->setEnabled(model->TabType() != TABTYPE::ExportedEvents);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -111,6 +111,7 @@ private:
     Options& m_options = Options::GetInstance();
     StatusBar * m_statusBar;
     QStringList m_recentFiles;
+    QString m_lastOpenFolder;
 
     // m_logTabs is used to store all the log tabs that MainWindow has open, by their TreeModels.
     // That way, a user can close or start live capture on any tab at any time, instead of only

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -8,6 +8,9 @@
 #include <QSettings>
 #include <QSysInfo>
 
+const QString Options::DefaultColorWhite { "#ffffff" };
+const QString Options::DefaultColorGray { "#e5e5e5" };
+
 void Options::ReadSettings()
 {
     QString iniPath = PathHelper::GetConfigIniPath();
@@ -101,4 +104,9 @@ void Options::LoadHighlightFilter(const QString& filterName)
 int Options::getSyntaxHighlightLimit() const
 {
     return m_syntaxHighlightLimit;
+}
+
+QString Options::getBackgroundColor() const
+{
+    return m_backgroundColor;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -28,6 +28,7 @@ void Options::ReadSettings()
     m_defaultFilterName = settings.value("defaultHighlightFilter", "None").toString();
     m_captureAllTextFiles = settings.value("liveCaptureAllTextFiles", true).toBool();
     m_syntaxHighlightLimit = settings.value("syntaxHighlightLimit", 15000).toInt();
+    m_backgroundColor = settings.value("backgroundColor", DefaultColorWhite).toString();
 
     settings.endGroup();
 

--- a/src/options.h
+++ b/src/options.h
@@ -21,6 +21,7 @@ private:
     QString m_defaultFilterName;
     HighlightOptions m_defaultHighlightOpts;
     int m_syntaxHighlightLimit;
+    QString m_backgroundColor;
 
 public:
     static Options& GetInstance()
@@ -41,4 +42,8 @@ public:
     QString getDefaultFilterName();
     HighlightOptions getDefaultHighlightOpts();
     int getSyntaxHighlightLimit() const;
+    QString getBackgroundColor() const;
+
+    const static QString DefaultColorWhite;
+    const static QString DefaultColorGray;
 };

--- a/src/optionsdlg.cpp
+++ b/src/optionsdlg.cpp
@@ -54,6 +54,13 @@ void OptionsDlg::WriteSettings()
     settings.setValue("liveCaptureAllTextFiles", captureAllTextFiles);
     settings.setValue("defaultHighlightFilter", currFilter);
     settings.setValue("syntaxHighlightLimit", syntaxHighlightLimit);
+
+    if (ui->useGrayBackground->isEnabled())
+    {
+        settings.setValue(
+            "backgroundColor",
+            ui->useGrayBackground->isChecked() ? Options::DefaultColorGray : Options::DefaultColorWhite);
+    }
     settings.endGroup();
 
     Options::GetInstance().ReadSettings();
@@ -86,6 +93,12 @@ void OptionsDlg::ReadSettings()
     ui->startFutureLiveCapture->setChecked(liveEnable);
     ui->captureAllTextFiles->setChecked(captureAllTextFiles);
     ui->syntaxHighlightLimitSpinBox->setValue(syntaxHighlightLimit);
+
+    // Don't change the background color from dialog if it's customized directly in INI file.
+    QString backgroundColor = options.getBackgroundColor();
+    ui->useGrayBackground->setEnabled(
+        backgroundColor == Options::DefaultColorGray || backgroundColor == Options::DefaultColorWhite);
+    ui->useGrayBackground->setChecked(backgroundColor == Options::DefaultColorGray);
 
     // load all saved filters for default filters
     ui->defaultHighlightComboBox->addItem(QString("None"));

--- a/src/optionsdlg.ui
+++ b/src/optionsdlg.ui
@@ -200,6 +200,16 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="useGrayBackground">
+          <property name="toolTip">
+           <string>Set background color to gray or white for log views and value dialog. Apply to new tabs.</string>
+          </property>
+          <property name="text">
+           <string>Use gray background</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QFormLayout" name="formLayout">
           <item row="0" column="0">
            <widget class="QLabel" name="syntaxHighlightLimitLabel">

--- a/src/valuedlg.cpp
+++ b/src/valuedlg.cpp
@@ -55,6 +55,8 @@ ValueDlg::ValueDlg(QWidget *parent) :
     m_id = QString("");
     m_key = QString("");
 
+    setStyleSheet(QString("QTextEdit { background-color: %1; }").arg(options.getBackgroundColor()));
+
     QFile sqlsyntaxcss(":/sqlsyntax.css");
     sqlsyntaxcss.open(QIODevice::ReadOnly);
     QTextStream textStream(&sqlsyntaxcss);

--- a/src/zoomabletreeview.cpp
+++ b/src/zoomabletreeview.cpp
@@ -1,4 +1,5 @@
 #include "zoomabletreeview.h"
+#include "options.h"
 
 #include <QApplication>
 #include <QDebug>
@@ -11,6 +12,9 @@ qreal ZoomableTreeView::sm_savedFontPointSize { 0 };
 ZoomableTreeView::ZoomableTreeView(QWidget *parent)
     :QTreeView(parent)
 {
+    Options& options = Options::GetInstance();
+    parent->setStyleSheet(QString("QTreeView { background-color: %1; }").arg(options.getBackgroundColor()));
+
     QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     fixedFont.setPointSizeF(sm_savedFontPointSize);
     this->setFont(fixedFont);


### PR DESCRIPTION
In lieu of a dark theme, add an option to show log view and value dialog
in gray background to reduce contrast.
For simplicity, the UI option is a single check box; but for future
flexibility, the option is saved as a color string instead of a Boolean
value in the settings file.
If desired, we can allow setting different color in the UI later. The
code also recognized if the color is “hacked” in the settings file and
avoid overwriting it.