### PR TITLE
Update the version of Qt used in Linux from 5.7 to 5.7.1

### DIFF
--- a/script/before_install_linux.sh
+++ b/script/before_install_linux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-add-apt-repository -y ppa:beineri/opt-qt57-trusty
+add-apt-repository -y ppa:beineri/opt-qt571-trusty
 apt-get update -y
 apt-get install -y \
   qt57declarative \


### PR DESCRIPTION
travis CI was failing with version 5.7.1, the repository was either down or not supported anymore.
I Upgraded the version used in the Linux configuration to use Qt 5.7.1