### PR TITLE
Add Evergreen State theme

### DIFF
--- a/src/optionsdlg.cpp
+++ b/src/optionsdlg.cpp
@@ -91,6 +91,7 @@ void OptionsDlg::ReadSettings()
     ui->startFutureLiveCapture->setChecked(liveEnable);
     ui->captureAllTextFiles->setChecked(captureAllTextFiles);
     ui->syntaxHighlightLimitSpinBox->setValue(syntaxHighlightLimit);
+    ui->themeComboBox->addItems(ThemeUtils::GetThemeNames());
     ui->themeComboBox->setCurrentText(themeName);
 
     // load all saved filters for default filters

--- a/src/optionsdlg.cpp
+++ b/src/optionsdlg.cpp
@@ -91,7 +91,13 @@ void OptionsDlg::ReadSettings()
     ui->startFutureLiveCapture->setChecked(liveEnable);
     ui->captureAllTextFiles->setChecked(captureAllTextFiles);
     ui->syntaxHighlightLimitSpinBox->setValue(syntaxHighlightLimit);
-    ui->themeComboBox->addItems(ThemeUtils::GetThemeNames());
+
+    const auto& themeNames = ThemeUtils::GetThemeNames();
+    ui->themeComboBox->addItems(themeNames);
+    if (!themeNames.contains(themeName))
+    {
+        themeName = "Native";
+    }
     ui->themeComboBox->setCurrentText(themeName);
 
     // load all saved filters for default filters
@@ -155,7 +161,6 @@ void OptionsDlg::on_serviceEnable_clicked()
 
 void OptionsDlg::on_themeComboBox_currentTextChanged(const QString &themeName)
 {
-    qDebug() << "Theme: " << themeName;
     ThemeUtils::SwitchTheme(themeName, this->parentWidget());
 }
 
@@ -169,6 +174,11 @@ void OptionsDlg::on_OptionsDlg_rejected()
     // Revert the theme back if the user cancels the dialog
     Options& options = Options::GetInstance();
     auto themeNameSettings = options.getTheme();
+    if (!ThemeUtils::GetThemeNames().contains(themeNameSettings))
+    {
+        themeNameSettings = "Native";
+    }
+
     auto themeNameUi = ui->themeComboBox->currentText();
     // Only apply a theme change if necessary
     if (themeNameSettings != themeNameUi)

--- a/src/optionsdlg.ui
+++ b/src/optionsdlg.ui
@@ -209,28 +209,7 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QComboBox" name="themeComboBox">
-            <item>
-             <property name="text">
-              <string>Native</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Dark Fusion</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Solarized Light</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Solarized Dark</string>
-             </property>
-            </item>
-           </widget>
+           <widget class="QComboBox" name="themeComboBox"/>
           </item>
          </layout>
         </item>

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -107,7 +107,7 @@ std::unique_ptr<QPalette> GetEvergreenStatePalette(QWidget*)
     palette->setColor(QPalette::WindowText,      QColor(0xf1f1f1));
     palette->setColor(QPalette::Base,            QColor(0x2e3c18));
     palette->setColor(QPalette::AlternateBase,   QColor(0xffff7f));
-    palette->setColor(QPalette::ToolTipBase,     QColor(0xc8b394));
+    palette->setColor(QPalette::ToolTipBase,     QColor(0x4b3a29));
     palette->setColor(QPalette::ToolTipText,     QColor(0xf1f1f1));
     palette->setColor(QPalette::Text,            QColor(0xdadada));
     palette->setColor(QPalette::Button,          QColor(0x4d6625));

--- a/src/theme.h
+++ b/src/theme.h
@@ -4,14 +4,11 @@
 
 class QPalette;
 class QString;
+class QStringList;
 class QWidget;
 
 class Theme {
 private:
-    static std::unique_ptr<QPalette> GetNativePalette(QWidget* widget);
-    static std::unique_ptr<QPalette> GetDarkPalette();
-    static std::unique_ptr<QPalette> GetSolarizedLightPalette();
-    static std::unique_ptr<QPalette> GetSolarizedDarkPalette();
     static QString GetDefaultStyle();
     static QString sm_defaultStyle;
 
@@ -20,6 +17,7 @@ private:
     std::unique_ptr<QPalette> m_palette;
 public:
     Theme(bool isFusionStyle, bool isDark, std::unique_ptr<QPalette> palette);
+    static QStringList GetThemeNames();
     static std::unique_ptr<Theme> ThemeFactory(const QString& themeName, QWidget* widget);
     void Activate();
 };

--- a/src/themeutils.cpp
+++ b/src/themeutils.cpp
@@ -13,6 +13,11 @@ void ThemeUtils::SwitchTheme(const QString& themeName, QWidget* widget)
     theme->Activate();
 }
 
+QStringList ThemeUtils::GetThemeNames()
+{
+    return Theme::GetThemeNames();
+}
+
 double ThemeUtils::Luminance(QColor color)
 {
     // https://www.w3.org/TR/WCAG/#relativeluminancedef

--- a/src/themeutils.cpp
+++ b/src/themeutils.cpp
@@ -4,13 +4,21 @@
 #include <algorithm>
 #include <cmath>
 #include <QColor>
+#include <QDebug>
 #include <QFileSelector>
 #include <QPalette>
 
 void ThemeUtils::SwitchTheme(const QString& themeName, QWidget* widget)
 {
     auto theme = Theme::ThemeFactory(themeName, widget);
-    theme->Activate();
+    if (theme)
+    {
+        theme->Activate();
+    }
+    else
+    {
+        qDebug() << "Unsupported theme:" << themeName;
+    }
 }
 
 QStringList ThemeUtils::GetThemeNames()

--- a/src/themeutils.h
+++ b/src/themeutils.h
@@ -2,8 +2,10 @@
 
 class QColor;
 class QString;
+class QStringList;
 
 namespace ThemeUtils {
+    QStringList GetThemeNames();
     void SwitchTheme(const QString& themeName, QWidget* widget);
     double Luminance(QColor color);
     double ContrastRatio(QColor a, QColor b);


### PR DESCRIPTION
Add a mid-darkness and mid-contrast green theme.
Refactor Theme class a bit to decouple it with the rest of project, so adding a theme just requires a free function and an entry to the map, no need to edit or recompile other files.