### PR TITLE
Adjust tag color in value dialog

### DIFF
--- a/resources/sqlsyntax.css
+++ b/resources/sqlsyntax.css
@@ -5,21 +5,18 @@ body{
 
 /* Keyword */
 .k{
-    /*color: rgb(148,41,41);*/
     color: #cb4b16;
     /*font-weight: bold;*/
 }
 
 /* String */
 .s{
-    /*color: rgb(20,20,232);*/
     color: #268bd2;
 }
 
 /* Tag */
 .t{
-    /*color: rgb(231,98,225);*/
-    color: #d33682;
+    color: #cc6f6f;
 }
 
 /* Whitespace */
@@ -36,13 +33,11 @@ body{
 
 /* Open Parenthesis */
 .op{
-    /*color: rgb(57,166,57);*/
     color: #859900;
 }
 
 /* Close Parenthesis */
 .cp{
-    /*color: rgb(57,166,57);*/
     color: #859900;
 }
 

--- a/resources/sqlsyntax.css
+++ b/resources/sqlsyntax.css
@@ -16,7 +16,7 @@ body{
 
 /* Tag */
 .t{
-    color: #cc6f6f;
+    color: #2aa198;
 }
 
 /* Whitespace */

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -41,7 +41,7 @@ void Tokenizer::SetSQL()
 {
     m_rules = {
         LexicalRule(TokenType::String, QRegularExpression("\\G'([^']*)'")),
-        LexicalRule(TokenType::Tag, QRegularExpression("\\G([a-zA-Z\\d_\\$-]+:)")),
+        LexicalRule(TokenType::Tag, QRegularExpression("\\G([a-zA-Z\\d_\\$-]+:\\s)")),
         LexicalRule(TokenType::Keyword, QRegularExpression("\\G(ON|COMMIT|PRESERVE|INTEGER|ROWS|LOCAL|TEMPORARY|ELSE|CASE|END|WHEN|THEN|CREATE|INSERT|DROP|DELETE|INDEX|TABLE|SELECT|WHERE|INTO|VALUES|ON|AS|FROM|AND|NOT|LEFT|RIGHT|INNER|OUTER|JOIN|ORDER|GROUP|BY|IN|OR|SUM)\\b", QRegularExpression::CaseInsensitiveOption)),
         LexicalRule(TokenType::Whitespace, QRegularExpression("\\G([\\s]+)")),
         LexicalRule(TokenType::Float, QRegularExpression("\\G[\\d]+\\.[\\d]+")),


### PR DESCRIPTION
Found myself squinting at reading tag names in value dialogs when using
one of the three dark themes. Change the tag color slightly to suit both
dark and light themes.  Feel free to suggest changes.

Also change the tag regex to include an extra trailing space, so it
would not match drive letters, class::method names or timestamps as
much.

Binary available in internal win.latest share.