### PR TITLE
Update README with status of master AND dev. Set version to 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Tableau Log Viewer
 
-[![Travis-CI](https://img.shields.io/travis/tableau/tableau-log-viewer/dev.svg?label=Linux%20build)](https://travis-ci.org/tableau/tableau-log-viewer) [![AppVeyor](https://img.shields.io/appveyor/ci/tableau/tableau-log-viewer/dev.svg?label=Windows%20build)](https://ci.appveyor.com/project/tableau/tableau-log-viewer/branch/dev)
+**Master branch** | [![Travis-CI](https://img.shields.io/travis/tableau/tableau-log-viewer/master.svg?label=Linux%20build)](https://travis-ci.org/tableau/tableau-log-viewer) | [![AppVeyor](https://img.shields.io/appveyor/ci/tableau/tableau-log-viewer/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/tableau/tableau-log-viewer/branch/master)
+:--|---|---
+**Dev branch** | [![Travis-CI](https://img.shields.io/travis/tableau/tableau-log-viewer/dev.svg?label=Linux%20build)](https://travis-ci.org/tableau/tableau-log-viewer) | [![AppVeyor](https://img.shields.io/appveyor/ci/tableau/tableau-log-viewer/dev.svg?label=Windows%20build)](https://ci.appveyor.com/project/tableau/tableau-log-viewer/branch/dev)
 
 Tableau Log Viewer is cross-platform tool with a simple interface that has a single purpose of making it easy to quickly glance over Tableau log files.
 
@@ -16,6 +18,8 @@ Overview
 
 How do I use Tableau Log Viewer?
 ---------------
+You can get the latest release in the [Releases Section](https://github.com/tableau/tableau-log-viewer/releases)
+
 Simply launch the application and drag'n'drop Tableau's log file. Both Tableau Desktop and [most] Tableau Server log files are supported.
 Take a look at our [wiki](https://github.com/tableau/tableau-log-viewer/wiki) to get more details on the features and usage of TLV.
 

--- a/src/tableau-log-viewer.pro
+++ b/src/tableau-log-viewer.pro
@@ -73,5 +73,5 @@ ICON = ../resources/images/tlv.icns
 
 CONFIG += c++14
 
-VERSION = 1.0.0.0
+VERSION = 1.1.0.0
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"


### PR DESCRIPTION
Set TLV version to 1.1
Update README with master and dev branch status.
In GitHub, it should look like this:

![image](https://cloud.githubusercontent.com/assets/1087437/23972118/ce46c7e4-098d-11e7-9f1a-3abeb1121b64.png)

There's is no easy way to display the "current" branch, or to only show the badges in dev (some approaches I saw involved having branch-specific commit that then you would have to be careful to not overwrite in the next merge/pull-request). The "Just-display-all-branches" approach is just easier to deal with in the long term.

I also added an explicit link to the releases section in the README as some users were not finding the link at the top.