### PR TITLE
Display booleans/null/undefined correctly

### DIFF
--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -637,6 +637,18 @@ void TreeModel::GetFlatJson(const QString& key, const QJsonValue& value, QVector
             GetFlatJson(itemKey, itemValue, stringList);
         }
     }
+    else if (value.isBool())
+    {
+        stringList.append(KeyValueString(key, QString(value.toBool() ? "true" : "false")));
+    }
+    else if (value.isNull())
+    {
+        stringList.append(KeyValueString(key, QString("null")));
+    }
+    else if (value.isUndefined())
+    {
+        stringList.append(KeyValueString(key, QString("undefined")));
+    }
     else
     {
         stringList.append(KeyValueString(key, value.toString()));


### PR DESCRIPTION
So far, booleans, nulls and undefined from the log files were just
skipped instead of being displayed.
This commit fixes that shortcoming.