### PR TITLE
Easier highlighting

### DIFF
--- a/src/column.h
+++ b/src/column.h
@@ -1,7 +1,7 @@
 #ifndef COLUMN_H
 #define COLUMN_H
 
-enum COL {
+enum COL : short {
     ID = 0,
     File,
     Time,

--- a/src/filtertab.cpp
+++ b/src/filtertab.cpp
@@ -16,6 +16,13 @@ FilterTab::FilterTab(QWidget *parent, QString valueText, QColor backgroundColor)
     SetTitle(valueText);
     SetBackgroundColor(backgroundColor);
 
+    ui->comboBoxMode->addItem("Contains",SearchMode::Contains);
+    ui->comboBoxMode->addItem("Equals",SearchMode::Equals);
+    ui->comboBoxMode->addItem("Starts with",SearchMode::StartsWith);
+    ui->comboBoxMode->addItem("Ends with",SearchMode::EndsWith);
+    ui->comboBoxMode->addItem("Regular expression",SearchMode::Regex);
+    ui->comboBoxMode->setCurrentIndex(ui->comboBoxMode->findData(SearchMode::Contains));
+
     // mapping of COL and checkBox widgets
     m_mapColToBox = std::map<COL, QCheckBox*> {
         {COL::Severity,   ui->checkBoxSeverity},
@@ -60,7 +67,7 @@ void FilterTab::HideColorWidget()
 void FilterTab::SetSearchOptions(const SearchOpt& options)
 {
     ui->filterLineEdit->setText(options.m_value);
-    ui->checkBoxRegEx->setChecked(options.m_useRegex);
+    ui->comboBoxMode->setCurrentIndex(ui->comboBoxMode->findData(options.m_mode));
     ui->checkBoxCase->setChecked(options.m_matchCase);
     for (auto& colToBox : m_mapColToBox)
     {
@@ -72,7 +79,7 @@ SearchOpt FilterTab::GetSearchOptions()
 {
     SearchOpt options;
     options.m_value = ui->filterLineEdit->text();
-    options.m_useRegex = ui->checkBoxRegEx->isChecked();
+    options.m_mode = static_cast<SearchMode>(ui->comboBoxMode->currentData().toInt());
     options.m_matchCase = ui->checkBoxCase->isChecked();
 
     for (const auto& colToBox : m_mapColToBox)

--- a/src/filtertab.ui
+++ b/src/filtertab.ui
@@ -45,9 +45,9 @@
          </spacer>
         </item>
         <item>
-         <widget class="QCheckBox" name="checkBoxRegEx">
-          <property name="text">
-           <string>Use regular e&amp;xpression</string>
+         <widget class="QComboBox" name="comboBoxMode">
+          <property name="editable">
+           <bool>false</bool>
           </property>
          </widget>
         </item>

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -1010,7 +1010,7 @@ void LogTab::RowHighlightSelected(COL column)
     // Figure out which ones are already filtered
     QSet<QString> alreadyFiltered;
     for (const auto& filter : m_treeModel->GetHighlightFilters()) {
-       if ((filter.m_keys.size()==1) && (filter.m_keys[0]==column)) {
+       if ((filter.m_keys.size()==1) && (filter.m_mode==SearchMode::Equals) && (filter.m_keys[0]==column)) {
           alreadyFiltered.insert(filter.m_value);
        }
     }
@@ -1021,6 +1021,7 @@ void LogTab::RowHighlightSelected(COL column)
        if (alreadyFiltered.contains(value)) continue;
        SearchOpt newOpt;
        newOpt.m_keys.append(column);
+       newOpt.m_mode = SearchMode::Equals;
        newOpt.m_value = value;
        newOpt.m_backgroundColor = m_treeModel->m_colorLibrary.GetNextColor();
        m_treeModel->AddHighlightFilter(newOpt);

--- a/src/logtab.h
+++ b/src/logtab.h
@@ -39,7 +39,7 @@ private:
     void InitTwoRowsMenu();
     void InitMultipleRowsMenu();
     void InitHeaderMenu();
-    void SetColumn(int column, int width, bool isHidden);
+    void SetColumn(COL column, int width, bool isHidden);
     void ShowItemDetails(const QModelIndex&);
     void CopyItemDetails(bool textOnly, bool normalized) const;
     void CopyItemDetailsAsHtml() const;
@@ -68,8 +68,9 @@ private:
     QMenu *m_headerMenu;
     ValueDlg *m_valueDlg;
     std::vector<std::unique_ptr<QTemporaryFile>> m_tempFiles;
-    QAction *m_exportToTabAction;
     QAction *m_highlightSelectedType;
+    QMenu *m_highlightSelectedMenu;
+    QAction *m_exportToTabAction;
     QAction *m_copyItemsHtmlAction;
     QAction *m_copyItemsTextAction;
     QAction *m_copyItemsNormalizedTextAction;
@@ -93,7 +94,7 @@ private slots:
     void RowHideSelectedType();
     void RowFindNextSelectedType();
     void RowFindPrevSelectedType();
-    void RowHighlightSelectedType();
+    void RowHighlightSelected(COL column);
     void RowShowGlobalDateTime();
     void RowShowGlobalTime();
     void RowShowTimeDeltas();

--- a/src/logtab.h
+++ b/src/logtab.h
@@ -69,6 +69,7 @@ private:
     ValueDlg *m_valueDlg;
     std::vector<std::unique_ptr<QTemporaryFile>> m_tempFiles;
     QAction *m_exportToTabAction;
+    QAction *m_highlightSelectedType;
     QAction *m_copyItemsHtmlAction;
     QAction *m_copyItemsTextAction;
     QAction *m_copyItemsNormalizedTextAction;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1251,9 +1251,10 @@ void MainWindow::FindImpl(int offset, bool findHighlight)
     if (model->rowCount() == 0)
         return;
 
+    QVector<SearchOpt> findFilter{model->m_findOpts};
     const QVector<SearchOpt>& filters = (findHighlight) ?
-        model->GetHighlightFilters() :
-        QVector<SearchOpt> {model->m_findOpts};
+        static_cast<const QVector<SearchOpt>&>(model->GetHighlightFilters()) :
+        findFilter;
 
     int start = tree->currentIndex().row();
     // If nothing is selected, the current index is -1. Force to start at 0 to avoid an infinite loop.

--- a/src/searchopt.h
+++ b/src/searchopt.h
@@ -8,6 +8,14 @@
 #include <QString>
 #include <QVector>
 
+enum SearchMode : short {
+    Equals,
+    Contains,
+    StartsWith,
+    EndsWith,
+    Regex
+};
+
 class SearchOpt
 {
 public:
@@ -19,12 +27,8 @@ public:
     QString m_value;
     QVector<COL> m_keys;
     bool m_matchCase;
-    bool m_useRegex;
+    SearchMode m_mode;
     QColor m_backgroundColor;
-
-private:
-    static QMap<COL, QString> sm_mapColToString;
-    static QMap<QString, COL> sm_mapStringToCol;
 };
 
 #endif // SEARCHOPT_H

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -660,7 +660,7 @@ void TreeModel::GetFlatJson(const QString& key, const QJsonValue& value, QVector
     }
 }
 
-HighlightOptions TreeModel::GetHighlightFilters() const
+const HighlightOptions& TreeModel::GetHighlightFilters() const
 {
     return m_highlightOpts;
 }

--- a/src/treemodel.h
+++ b/src/treemodel.h
@@ -71,7 +71,7 @@ public:
     QString GetValueFullString(const QModelIndex& idx, bool singleLineFormat = false) const;
     TABTYPE TabType() const;
     void SetTabType(TABTYPE type);
-    HighlightOptions GetHighlightFilters() const;
+    const HighlightOptions& GetHighlightFilters() const;
     void SetHighlightFilters(const HighlightOptions& highlightOpts);
     void AddHighlightFilter(const SearchOpt& filter);
     bool HasHighlightFilters() const;


### PR DESCRIPTION
This set of commits makes highlighting of events easier:

* It adds new highlight filter modes `equals`, `begins with` and `ends with`
* It adds `Highligh this session/request/thread/severity` functionality
* All `Highlight this <whatever>` actions can now deal with multiple selected events

For more details, see the individual git commit messages