### PR TITLE
Add support for multiple selected events to `Hide this event`

### DIFF
--- a/src/logtab.h
+++ b/src/logtab.h
@@ -68,6 +68,8 @@ private:
     QMenu *m_headerMenu;
     ValueDlg *m_valueDlg;
     std::vector<std::unique_ptr<QTemporaryFile>> m_tempFiles;
+    QAction *m_hideSelectedEvent;
+    QAction *m_hideSelectedType;
     QAction *m_highlightSelectedType;
     QMenu *m_highlightSelectedMenu;
     QAction *m_exportToTabAction;


### PR DESCRIPTION
`Hide this event` and `Hide all events of this type` now support
multiple selected events. Not that I really use this functionality.
The purpose of this commit is mostly to make the behavior consistent
with `Highlight all events of this type` for which support for
multiple selected events was added recently.