### PR TITLE
Visualize query plan without additional surrounding JSON tags

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -620,9 +620,12 @@ void LogTab::ShowDetails(const QModelIndex& idx, ValueDlg& valueDlg)
     {
         auto event = m_treeModel->GetEvent(idx);
         auto valObject = event["v"].toObject();
-        QJsonDocument doc(valObject);
-        QString jsonString(doc.toJson(QJsonDocument::Compact));
-        valueDlg.SetQuery(jsonString);
+        if (valObject.contains("plan")) {
+           auto planObject = valObject["plan"].toObject();
+           QJsonDocument doc(planObject);
+           QString jsonString(doc.toJson(QJsonDocument::Compact));
+           valueDlg.SetQuery(jsonString);
+        }
     }
 }
 

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -616,7 +616,7 @@ void LogTab::ShowDetails(const QModelIndex& idx, ValueDlg& valueDlg)
             valueDlg.SetQuery(queryText);
         }
     }
-    else if (valueDlg.m_key == "query-plan")
+    else if (valueDlg.m_key == "query-plan" || valueDlg.m_key == "optimizer-step")
     {
         auto event = m_treeModel->GetEvent(idx);
         auto valObject = event["v"].toObject();


### PR DESCRIPTION
The query plan is contained within the sub-property 'plan' of the log event `query-plan`.
"Visualize query" should only display the plan, without the surrounding JSON nodes.
Also, we did not yet support query plans logged as part of the event type `optimizer-step`.