### PR TITLE
Do not try to set font size to 0

### DIFF
--- a/src/zoomabletreeview.cpp
+++ b/src/zoomabletreeview.cpp
@@ -13,7 +13,9 @@ ZoomableTreeView::ZoomableTreeView(QWidget *parent)
     :QTreeView(parent)
 {
     QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-    fixedFont.setPointSizeF(sm_savedFontPointSize);
+    if (sm_savedFontPointSize > 0) {
+       fixedFont.setPointSizeF(sm_savedFontPointSize);
+    }
     this->setFont(fixedFont);
 }
 


### PR DESCRIPTION
With this small change we no longer try to set the font size to 0 and thereby avoid a warning message being written to the terminal