### PR TITLE
Use more sensible default locations for file pickers

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -91,6 +91,8 @@ private:
     LogTab * GetCurrentLogTab();
     LogTab * GetLogTab(int index);
 
+    QString GetOpenDefaultFolder();
+    QStringList PickLogFilesToOpen(QString caption);
     void UpdateRecentFilesMenu();
     void ClearRecentFileMenu();
     void AddRecentFile(const QString& path);


### PR DESCRIPTION
So far, the file pickers used for `Open in new tab` and `Merge into tab`
were opened in the current working directory. This usually makes no
sense since the CWD is e.g. on Windows the directory where the Log
Viewer executable itself was installed.

This commit introduces a better logic to pick a default location for the
file pickers:
* It first tries to open the file picker in the directory of the
  currently selected log tab.
* If that fails, it opens the file picker for the last used directory
* If the directory is no longer valid (or was never set), we fallback
  first to the Beta log directory and then to the log directory (in this
  order - if you have both installed, you usually want to debug the Beta
  and not the Release version)
* If neither of both log directories exists, we try the `Documents`
  folder
* Still no luck? Fallback to the current working directory