### PR TITLE
Fix multi item hide/delete

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -257,6 +257,7 @@ void LogTab::keyPressEvent(QKeyEvent *event)
     case Qt::Key_Backspace:
     case Qt::Key_Delete:
         RowHideSelected();
+        break;
     default:
         // Check keys with modifiers together and ensure regular key events get propagated.
         if ((event->key() == Qt::Key_C) &&
@@ -948,6 +949,11 @@ void LogTab::RowHideSelected()
 {
     ui->treeView->setUpdatesEnabled(false);
     auto idxList = ui->treeView->selectionModel()->selectedRows();
+
+    // Sort the indices in reverse order. Remove the items from the
+    // end first to make sure indices stay valid after each removal
+    std::sort(idxList.rbegin(), idxList.rend());
+
     for (const auto& idx : idxList) {
        m_treeModel->removeRow(idx.row(), idx.parent());
     }


### PR DESCRIPTION
Multi deletion had a very strange behavior. Sometimes it would remove some items (not necessarily the one you selected) and sometimes it would just crash TLV.

This is because every time we remove a row, the indices are updates. So if we remove index 5 and 6, we might actually be deleting index 5 and 7.

At first I thought about just doing the loop in reverse since I though the selected indices are always sorted. However, doing selection with Ctrl+click is also valid and, in this case, order is not guaranteed.

Seems like the easiest solution is to sort the selected indices in reverse order and then remove the items (higher index should be removed first).

Some discussion in the Qt forum: http://www.qtcentre.org/threads/32721-How-can-I-remove-a-list-of-selected-items-in-the-QListView-in-QT-4-6