### PR TITLE
Make find only search non hidden rows

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1265,22 +1265,36 @@ void MainWindow::FindImpl(int offset, bool findHighlight)
         else if (i < 0)
             i = model->rowCount() - 1;
 
-        for (SearchOpt searchOpt : filters)
+        // If highlight only mode is on, don't search hidden rows
+        bool searchRow = true;
+        if (model->m_highlightOnlyMode)
         {
-            for (COL col : searchOpt.m_keys)
+            QModelIndex idx;
+            if(tree->isRowHidden(i, idx))
             {
-                QModelIndex idx = model->index(i, col);
-                QString data = (col == COL::Value) ?
-                    model->GetValueFullString(idx, true) :
-                    model->data(idx, Qt::DisplayRole).toString();
-                if (searchOpt.HasMatch(data))
+                searchRow = false;
+            }
+        }
+
+        if (searchRow)
+        {
+            for (SearchOpt searchOpt : filters)
+            {
+                for (COL col : searchOpt.m_keys)
                 {
-                    tree->setCurrentIndex(idx);
-                    QString msg = (filters.size() == 1) ?
-                        QString("Found '%1' on line %2").arg(searchOpt.m_value, model->data(model->index(i, 0), Qt::DisplayRole).toString()) :
-                        QString("Found a match on line %1").arg(model->data(model->index(i, 0), Qt::DisplayRole).toString());
-                    statusBar()->showMessage(msg, 3000);
-                    return;
+                    QModelIndex idx = model->index(i, col);
+                    QString data = (col == COL::Value) ?
+                        model->GetValueFullString(idx, true) :
+                        model->data(idx, Qt::DisplayRole).toString();
+                    if (searchOpt.HasMatch(data))
+                    {
+                        tree->setCurrentIndex(idx);
+                        QString msg = (filters.size() == 1) ?
+                            QString("Found '%1' on line %2").arg(searchOpt.m_value, model->data(model->index(i, 0), Qt::DisplayRole).toString()) :
+                            QString("Found a match on line %1").arg(model->data(model->index(i, 0), Qt::DisplayRole).toString());
+                        statusBar()->showMessage(msg, 3000);
+                        return;
+                    }
                 }
             }
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1256,6 +1256,10 @@ void MainWindow::FindImpl(int offset, bool findHighlight)
         start = 0;
     }
     int i = start;
+
+    // Used for isRowHidden()
+    QModelIndex idx;
+
     while (true)
     {
         i += offset;
@@ -1265,18 +1269,7 @@ void MainWindow::FindImpl(int offset, bool findHighlight)
         else if (i < 0)
             i = model->rowCount() - 1;
 
-        // If highlight only mode is on, don't search hidden rows
-        bool searchRow = true;
-        if (model->m_highlightOnlyMode)
-        {
-            QModelIndex idx;
-            if(tree->isRowHidden(i, idx))
-            {
-                searchRow = false;
-            }
-        }
-
-        if (searchRow)
+        if (!tree->isRowHidden(i, idx))
         {
             for (SearchOpt searchOpt : filters)
             {


### PR DESCRIPTION
Currently rows are hidden with setRowHidden to hide rows during highlight only mode (right click > hide item removes the rows entirely, so FindImpl already won't find those).

fixes #54 