### PR TITLE
More useful names for `exported data` tabs

### DIFF
--- a/src/column.h
+++ b/src/column.h
@@ -17,4 +17,23 @@ enum COL : short {
     Value
 };
 
+inline const char* GetColumnName(COL column) {
+    switch (column) {
+       case ID: return "ID";
+       case File: return "File";
+       case Time: return "Time";
+       case Elapsed: return "Elapsed";
+       case PID: return "PID";
+       case TID: return "TID";
+       case Severity: return "Severity";
+       case Request: return "Request";
+       case Session: return "Session";
+       case Site: return "Site";
+       case User: return "User";
+       case Key: return "Key";
+       case Value: return "Value";
+    }
+    return "unknown column";
+}
+
 #endif // COLUMN_H

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -818,11 +818,12 @@ void LogTab::ExportToNewTab()
     std::sort(idxList.begin(), idxList.end(), [](QModelIndex a, QModelIndex b) {
         return a.row() < b.row();
     });
-    emit exportToTab(idxList);
+    emit exportToTab(idxList,"exported data");
 }
 
 void LogTab::ExportToNewTab(COL column)
 {
+    // Generate the list of selected values
     auto selectionList = ui->treeView->selectionModel()->selectedRows();
     QSet<QString> exportedValues;
     for (const auto& selected : selectionList) {
@@ -830,6 +831,12 @@ void LogTab::ExportToNewTab(COL column)
        exportedValues.insert(value);
     }
 
+    // Build the name for the new tab
+    QStringList sortedValues=QStringList::fromSet(exportedValues);
+    sortedValues.sort();
+    QString name = QString(GetColumnName(column)) + " " + sortedValues.join(",");
+
+    // Generate the index list
     const int count = m_treeModel->rowCount();
     const QModelIndex root;
     QModelIndexList exportedIdxList;
@@ -842,7 +849,7 @@ void LogTab::ExportToNewTab(COL column)
         }
     }
 
-    emit exportToTab(exportedIdxList);
+    emit exportToTab(exportedIdxList, name);
 }
 
 void LogTab::OpenSelectedFile()

--- a/src/logtab.h
+++ b/src/logtab.h
@@ -114,7 +114,7 @@ private slots:
 
 signals:
     void menuUpdateNeeded();
-    void exportToTab(QModelIndexList list);
+    void exportToTab(QModelIndexList list, QString name);
     void openFile(QString);
 };
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -291,7 +291,7 @@ EventListPtr MainWindow::GetEventsFromFile(QString path, int & skippedCount)
     return events;
 }
 
-void MainWindow::ExportEventsToTab(QModelIndexList list)
+void MainWindow::ExportEventsToTab(QModelIndexList list, QString name)
 {
     auto events = std::make_shared<EventList>();
     TreeModel * model = GetCurrentTreeModel();
@@ -334,7 +334,9 @@ void MainWindow::ExportEventsToTab(QModelIndexList list)
     actionTail_current_tab->setEnabled(false);
     connect(logTab, &LogTab::menuUpdateNeeded, this, &MainWindow::UpdateMenuAndStatusBar);
     connect(logTab, &LogTab::exportToTab, this, &MainWindow::ExportEventsToTab);
-    int idx = tabWidget->addTab(logTab, "exported data");
+    QString shortName = name.size() < 30 ? name : (name.left(27) + "...");
+    int idx = tabWidget->addTab(logTab, shortName);
+    tabWidget->setTabToolTip(idx, name);
     tabWidget->setCurrentIndex(idx);
     logTab->setFocus();
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -39,7 +39,7 @@ private slots:
     void Recent_files_triggered(QAction * action);
     void UpdateTheme();
     void UpdateMenuAndStatusBar();
-    void ExportEventsToTab(QModelIndexList list);
+    void ExportEventsToTab(QModelIndexList list, QString name);
     bool LoadLogFile(QString);
 
     //Slots use underscores as per QT's automatic connection syntax


### PR DESCRIPTION
Instead of naming all tabs showing exported data simply `exported data`,
provide more meaningful tab names.