### PR TITLE
Fix to automatically display the datetime format when log spans multiple days

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -1114,7 +1114,7 @@ void LogTab::RowShowGlobalTime()
 void LogTab::RowShowTimeDeltas()
 {
     QModelIndex idx = ui->treeView->currentIndex();
-    auto datetime = idx.model()->index(idx.row(), COL::Time, idx.parent()).data(Qt::UserRole).toLongLong();
+    auto datetime = idx.model()->index(idx.row(), COL::Time, idx.parent()).data(Qt::UserRole).toDateTime().toMSecsSinceEpoch();
     m_treeModel->ShowDeltas(datetime);
 }
 

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -74,11 +74,6 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const
         case Qt::UserRole:
         {
             TreeItem* item = GetItem(index);
-            if (col == COL::Time)
-            {
-                QDateTime dateTime = item->Data(col).toDateTime();
-                return dateTime.toMSecsSinceEpoch();
-            }
             return item->Data(col);
             break;
         }


### PR DESCRIPTION
The code in LogTab::InitTreeView that determines whether to show the datetime OR time format by default was not working correctly.

It was assuming to be getting DateTime from the treemodel (from the COL::Time column). However, it was really getting an integer with the milliseconds since the epoch.

I fixed the TreeModel; the Qt::UserRole no longer has a special code path for the Time column. The "ShowRowDeltas" code had to be updated accordingly.