### PR TITLE
Parse log files as UTF8

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -31,7 +31,6 @@
 #include <QScrollBar>
 #include <QSettings>
 #include <QSignalMapper>
-#include <QTextStream>
 #include <QTime>
 #include <QTreeView>
 
@@ -268,10 +267,9 @@ EventListPtr MainWindow::GetEventsFromFile(QString path, int & skippedCount)
 
     if (logfile.open(QIODevice::ReadOnly))
     {
-        QTextStream in(&logfile);
-        while (!in.atEnd())
+        while (!logfile.atEnd())
         {
-            auto line = in.readLine().trimmed();
+            auto line = logfile.readLine().trimmed();
             if (line.isEmpty())
             {
                 continue;


### PR DESCRIPTION
In accordance with https://tools.ietf.org/html/rfc7159 and https://tools.ietf.org/html/rfc8259, json must be encoded as UTF8. So far, the log viewer did not read the JSON files as UTF8. Instead we relied on QTextStream which internally used a system-dependent encoding.

The logs written by Hyper are UTF8-encoded and the log viewer did not render non-ASCII characters correctly. Logs written by Tableau on the other hand only use plain ASCII characters and escape non-ASCII characters using JSON escape characters. Hence, this change fixes behavior for Hyper log files while at the same time not impacting Tableau log files negatively.