### PR TITLE
Add support for ART (Activity and Resource Tracing) data

### DIFF
--- a/src/column.h
+++ b/src/column.h
@@ -14,6 +14,7 @@ enum COL : short {
     Site,
     User,
     Key,
+    ART,
     Value
 };
 
@@ -31,6 +32,7 @@ inline const char* GetColumnName(COL column) {
        case Site: return "Site";
        case User: return "User";
        case Key: return "Key";
+       case ART: return "ART";
        case Value: return "Value";
     }
     return "unknown column";

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -35,7 +35,7 @@ void LogTab::InitTreeView(const EventListPtr events)
 {
     ui->treeView->setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);
 
-    QStringList headers = QString("ID;File;Time;Elapsed;PID;TID;Severity;Request;Session;Site;User;Key;Value").split(";");
+    QStringList headers = QString("ID;File;Time;Elapsed;PID;TID;Severity;Request;Session;Site;User;Key;ART;Value").split(";");
 
     // The parent of the model is this widget. The model will get destroyed when the widget is destroyed
     m_treeModel = new TreeModel(headers, events, this);
@@ -67,6 +67,7 @@ void LogTab::InitTreeView(const EventListPtr events)
     SetColumn(COL::Site, 180, true);
     SetColumn(COL::User, 30, true);
     SetColumn(COL::Key, 120, hasNoKey);
+    SetColumn(COL::ART, 30, hasNoKey);
     ui->treeView->SetAutoResizeColumns({COL::Time, COL::Elapsed});
 
     ui->treeView->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/src/treemodel.h
+++ b/src/treemodel.h
@@ -89,6 +89,7 @@ private:
     void AddChild(const QString& key, const QJsonValue& value, TreeItem* parent);
     void InsertChild(int position, const QJsonObject & event);
     QString JsonToString(const QJsonValue& json, const bool isSingleLine = true) const;
+    QJsonValue ConsolidateValueAndActivity(const QJsonObject& event) const;
     QColor ItemHighlightColor(const QModelIndex& idx) const;
     QString GetDeltaMSecs(QDateTime dateTime) const;
     TreeItem *GetItem(const QModelIndex &index) const;


### PR DESCRIPTION
Adding support for ART (Activity and Resource Tracing) data, a.k.a. the "a" key. a.k.a feature request #76 

The main challenge is that "a" is normally a nested object. "v" can also be an object. So we can't show the tree view for both by default.

I'm adding a function "ConsolidateValueAndActivity" it looks at the contents under "v" and "a" and comes with a new object that has both. Using this new object allows us to have compatibility with the tree view and all the other features.

The most common cases are:
- Most common: only "v" is provided => no changes
- Semi-common: both "v" and "a" are provided => the "a" contents are appended to "v" under the "~art" subkey

I added a new column. The header is "ART" and is very narrow.
- The content is either a black circle (⚫) if "a" was provided for the event or empty if it wasn't
- The tooltip is the nicely formatted "a" content

![image](https://user-images.githubusercontent.com/1087437/37070898-c3828880-216e-11e8-9139-0576c8d91b1d.png)
