### PR TITLE
Persist wrap text. Request #57

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -41,44 +41,104 @@ void Options::ReadSettings()
     }
 }
 
-QStringList Options::getSkippedText()
+void Options::WriteSettings()
+{
+    QString iniPath = PathHelper::GetConfigIniPath();
+    QSettings settings(iniPath, QSettings::IniFormat);
+
+    settings.beginGroup("Options");
+    settings.setValue("skippedText", m_skippedText);
+    settings.setValue("skippedState", m_skippedState);
+    settings.setValue("visualizationServiceEnable", m_visualizationServiceEnable);
+    settings.setValue("visualizationServiceURL", m_visualizationServiceURL);
+    settings.setValue("diffToolPath", m_diffToolPath);
+    settings.setValue("enableLiveCapture", m_futureTabsUnderLive);
+    settings.setValue("liveCaptureAllTextFiles", m_captureAllTextFiles);
+    settings.setValue("defaultHighlightFilter", m_defaultFilterName);
+    settings.setValue("syntaxHighlightLimit", m_syntaxHighlightLimit);
+    settings.setValue("theme", m_theme);
+    settings.setValue("notation", m_notation);
+    settings.endGroup();
+}
+
+QStringList Options::getSkippedText() const
 {
     return m_skippedText;
 }
 
-QBitArray Options::getSkippedState()
+void Options::setSkippedText(const QStringList &skippedText)
+{
+    m_skippedText = skippedText;
+}
+
+QBitArray Options::getSkippedState() const
 {
     return m_skippedState;
 }
 
-bool Options::getVisualizationServiceEnable()
+void Options::setSkippedState(const QBitArray &skippedState)
+{
+    m_skippedState = skippedState;
+}
+
+bool Options::getVisualizationServiceEnable() const
 {
     return m_visualizationServiceEnable;
 }
 
-QString Options::getVisualizationServiceURL()
+void Options::setVisualizationServiceEnable(const bool visualizationServiceEnable)
+{
+    m_visualizationServiceEnable = visualizationServiceEnable;
+}
+
+QString Options::getVisualizationServiceURL() const
 {
     return m_visualizationServiceURL;
 }
 
-QString Options::getDiffToolPath()
+void Options::setVisualizationServiceURL(const QString &visualizationServiceURL)
+{
+    m_visualizationServiceURL = visualizationServiceURL;
+}
+
+QString Options::getDiffToolPath() const
 {
     return m_diffToolPath;
 }
 
-bool Options::getFutureTabsUnderLive()
+void Options::setDiffToolPath(const QString &diffToolPath)
+{
+    m_diffToolPath = diffToolPath;
+}
+
+bool Options::getFutureTabsUnderLive() const
 {
     return m_futureTabsUnderLive;
 }
 
-bool Options::getCaptureAllTextFiles()
+void Options::setFutureTabsUnderLive(const bool futureTabsUnderLive)
+{
+    m_futureTabsUnderLive = futureTabsUnderLive;
+}
+
+bool Options::getCaptureAllTextFiles() const
 {
     return m_captureAllTextFiles;
 }
 
-QString Options::getDefaultFilterName()
+void Options::setCaptureAllTextFiles(const bool captureAllTextFiles)
+{
+    m_captureAllTextFiles = captureAllTextFiles;
+}
+
+QString Options::getDefaultFilterName() const
 {
     return m_defaultFilterName;
+}
+
+void Options::setDefaultFilterName(const QString &defaultFilterName)
+{
+    m_defaultFilterName = defaultFilterName;
 }
 
 HighlightOptions Options::getDefaultHighlightOpts()
@@ -106,12 +166,27 @@ int Options::getSyntaxHighlightLimit() const
     return m_syntaxHighlightLimit;
 }
 
-QString Options::getTheme()
+void Options::setSyntaxHighlightLimit(const int syntaxHighlightLimit)
+{
+    m_syntaxHighlightLimit = syntaxHighlightLimit;
+}
+
+QString Options::getTheme() const
 {
     return m_theme;
 }
 
-QString Options::getNotation()
+void Options::setTheme(const QString &theme)
+{
+    m_theme = theme;
+}
+
+QString Options::getNotation() const
 {
     return m_notation;
+}
+
+void Options::setNotation(const QString &notation)
+{
+    m_notation = notation;
 }

--- a/src/options.h
+++ b/src/options.h
@@ -31,18 +31,41 @@ public:
         return options;
     }
     void ReadSettings();
+    void WriteSettings();
     void LoadHighlightFilter(const QString& filterName);
 
-    QStringList getSkippedText();
-    QBitArray getSkippedState();
-    bool getVisualizationServiceEnable();
-    QString getVisualizationServiceURL();
-    QString getDiffToolPath();
-    bool getFutureTabsUnderLive();
-    bool getCaptureAllTextFiles();
-    QString getDefaultFilterName();
+    QStringList getSkippedText() const;
+    void setSkippedText(const QStringList& skippedText);
+
+    QBitArray getSkippedState() const;
+    void setSkippedState(const QBitArray& skippedState);
+
+    bool getVisualizationServiceEnable() const;
+    void setVisualizationServiceEnable(const bool visualizationServiceEnable);
+
+    QString getVisualizationServiceURL() const;
+    void setVisualizationServiceURL(const QString& visualizationServiceURL);
+
+    QString getDiffToolPath() const;
+    void setDiffToolPath(const QString& diffToolPath);
+
+    bool getFutureTabsUnderLive() const;
+    void setFutureTabsUnderLive(const bool futureTabsUnderLive);
+
+    bool getCaptureAllTextFiles() const;
+    void setCaptureAllTextFiles(const bool captureAllTextFiles);
+
+    QString getDefaultFilterName() const;
+    void setDefaultFilterName(const QString& defaultFilterName);
+
     HighlightOptions getDefaultHighlightOpts();
+
     int getSyntaxHighlightLimit() const;
-    QString getTheme();
-    QString getNotation();
+    void setSyntaxHighlightLimit(const int syntaxHighlightLimit);
+
+    QString getTheme() const;
+    void setTheme(const QString& theme);
+
+    QString getNotation() const;
+    void setNotation(const QString& notation);
 };

--- a/src/valuedlg.cpp
+++ b/src/valuedlg.cpp
@@ -21,6 +21,7 @@
 
 QByteArray ValueDlg::sm_savedGeometry { QByteArray() };
 qreal ValueDlg::sm_savedFontPointSize { 0 };
+bool ValueDlg::sm_savedWrapText { true };
 
 ValueDlg::ValueDlg(QWidget *parent) :
     QDialog(parent),
@@ -58,6 +59,8 @@ ValueDlg::ValueDlg(QWidget *parent) :
 
     ui->prevButton->setIcon(QIcon(ThemeUtils::GetThemedIcon(":/value-previous.png")));
     ui->nextButton->setIcon(QIcon(ThemeUtils::GetThemedIcon(":/value-next.png")));
+    ui->wrapTextCheck->setChecked(sm_savedWrapText);
+    SetWrapping(sm_savedWrapText);
 
     QFile sqlsyntaxcss(":/sqlsyntax.css");
     sqlsyntaxcss.open(QIODevice::ReadOnly);
@@ -165,7 +168,13 @@ void ValueDlg::on_prevButton_clicked()
 
 void ValueDlg::on_wrapTextCheck_clicked()
 {
-    if (ui->wrapTextCheck->isChecked())
+    SetWrapping(ui->wrapTextCheck->isChecked());
+}
+
+void ValueDlg::SetWrapping(const bool wrapText)
+{
+    sm_savedWrapText = wrapText;
+    if (sm_savedWrapText)
     {
         ui->textEdit->setLineWrapMode(QTextEdit::WidgetWidth);
     }
@@ -319,6 +328,7 @@ void ValueDlg::WriteSettings(QSettings& settings)
     settings.beginGroup("ValueDialog");
     settings.setValue("geometry", sm_savedGeometry);
     settings.setValue("fontPointSize", sm_savedFontPointSize);
+    settings.setValue("wrapText", sm_savedWrapText);
     settings.endGroup();
 }
 
@@ -327,5 +337,6 @@ void ValueDlg::ReadSettings(QSettings& settings)
     settings.beginGroup("ValueDialog");
     sm_savedGeometry = settings.value("geometry").toByteArray();
     sm_savedFontPointSize = settings.value("fontPointSize").toReal();
+    sm_savedWrapText = settings.value("wrapText").toBool();
     settings.endGroup();
 }

--- a/src/valuedlg.h
+++ b/src/valuedlg.h
@@ -48,6 +48,7 @@ private:
     QUrl GetVisualizeURL(QNetworkReply * const reply);
     void UploadQuery();
     void VisualizeQuery();
+    void SetWrapping(const bool wrapText);
 
     Ui::ValueDlg *ui;
     QString m_queryXML;
@@ -58,4 +59,5 @@ private:
 
     static QByteArray sm_savedGeometry;
     static qreal sm_savedFontPointSize;
+    static bool sm_savedWrapText;
 };


### PR DESCRIPTION
Addressing request #57. Persist Wrap text option

There are 2 code changes:
- Move the the logic to persist the "Options" settings group to the `Options` class instead of the `OptionsDlg`
- Add a "wrapText" setting that stores the state of the "Wrap text" checkbox in the Value Dialog. It is under the "ValueDlg" settings group (just like other settings for that dialog)

The intention of the first code change was to make adding support for "Wrap text" option more easy... but it turned out that it was not needed. It is still useful though, the refactored code is better (the OptionsDlg is not handling the settings file directly anymore) so I left it.