### PR TITLE
Allow choosing the notation directly from the value dialog

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -589,46 +589,11 @@ void LogTab::ShowDetails(const QModelIndex& idx, ValueDlg& valueDlg)
 {
     auto item_model = idx.model();
     auto idx_key = item_model->index(idx.row(), COL::Key, idx.parent());
-    QString value = m_treeModel->GetValueFullString(idx);
-
     auto idx_id = item_model->index(idx.row(), COL::ID, idx.parent());
-    valueDlg.m_id = idx_id.data().toString();
-    valueDlg.m_key = idx_key.data().toString();
-
-    valueDlg.setWindowTitle(QString("ID: %1 - Key: %2").arg(valueDlg.m_id, valueDlg.m_key));
-    int syntaxHighlightLimit = Options::GetInstance().getSyntaxHighlightLimit();
-    bool syntaxHighlight = (valueDlg.m_key != "msg" &&
-                            !valueDlg.m_key.isEmpty() &&
-                            syntaxHighlightLimit &&
-                            value.size() <= syntaxHighlightLimit);
-    valueDlg.SetText(value, syntaxHighlight);
-    valueDlg.SetQuery(QString(""));
-
-    if (valueDlg.m_key.startsWith("logical-query") ||
-        valueDlg.m_key == "federate-query" ||
-        valueDlg.m_key == "remote-query-planning" ||
-        valueDlg.m_key == "begin-query" ||
-        valueDlg.m_key == "end-query")
-    {
-        // Assume that queries starting with < have query function trees or logical-query.
-        // They normally start with "<?xml ...>", "<sqlproxy>" or "<query-function ...>"
-        auto queryText = m_treeModel->GetChildValueString(idx, QString("query"));
-        if (queryText.startsWith("<"))
-        {
-            valueDlg.SetQuery(queryText);
-        }
-    }
-    else if (valueDlg.m_key == "query-plan" || valueDlg.m_key == "optimizer-step")
-    {
-        auto event = m_treeModel->GetEvent(idx);
-        auto valObject = event["v"].toObject();
-        if (valObject.contains("plan")) {
-           auto planObject = valObject["plan"].toObject();
-           QJsonDocument doc(planObject);
-           QString jsonString(doc.toJson(QJsonDocument::Compact));
-           valueDlg.SetQuery(jsonString);
-        }
-    }
+    auto id = idx_id.data().toString();
+    auto key = idx_key.data().toString();
+    auto eventContent = m_treeModel->GetConsolidatedEventContent(idx);
+    valueDlg.SetContent(id,key,eventContent);
 }
 
 void LogTab::ShowItemDetails(const QModelIndex& idx)

--- a/src/qjsonutils.cpp
+++ b/src/qjsonutils.cpp
@@ -82,9 +82,20 @@ QJsonUtils::Notation QJsonUtils::GetNotationFromName(const QString& notationName
     }
     else
     {
-        qWarning() << "Invalid notation requested, defaulting to YAML";
+        qWarning() << "Invalid notation" << notationName << "requested, defaulting to YAML";
         return QJsonUtils::Notation::YAML;
     }
+}
+
+QString QJsonUtils::GetNameForNotation(Notation notation)
+{
+    for (auto it = notationNamesMap.begin(); it != notationNamesMap.end(); ++it) {
+        if (it.value() == notation) {
+            return it.key();
+        }
+    }
+    qWarning() << "Unhandled notation in GetNameForNotation";
+    return "";
 }
 
 namespace

--- a/src/qjsonutils.h
+++ b/src/qjsonutils.h
@@ -24,4 +24,5 @@ namespace QJsonUtils
     QStringList GetNotationNames();
 
     Notation GetNotationFromName(const QString& notationName);
+    QString GetNameForNotation(Notation notation);
 }

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -343,11 +343,16 @@ QJsonObject TreeModel::GetEvent(QModelIndex idx) const
     }
 }
 
-QString TreeModel::GetValueFullString(const QModelIndex& idx, bool singleLineFormat) const
+
+QJsonValue TreeModel::GetConsolidatedEventContent(QModelIndex idx) const
 {
     QJsonObject eventObj = GetEvent(idx);
-    QJsonValue valueObj = ConsolidateValueAndActivity(eventObj);
-    return JsonToString(valueObj, singleLineFormat);
+    return ConsolidateValueAndActivity(eventObj);
+}
+
+QString TreeModel::GetValueFullString(const QModelIndex& idx, bool singleLineFormat) const
+{
+    return JsonToString(GetConsolidatedEventContent(idx), singleLineFormat);
 }
 
 TABTYPE TreeModel::TabType() const

--- a/src/treemodel.h
+++ b/src/treemodel.h
@@ -68,6 +68,7 @@ public:
     void ShowDeltas(qint64 delta);
     bool IsHighlightedRow(int row) const;
     QJsonObject GetEvent(QModelIndex idx) const;
+    QJsonValue GetConsolidatedEventContent(QModelIndex idx) const;
     QString GetValueFullString(const QModelIndex& idx, bool singleLineFormat = false) const;
     TABTYPE TabType() const;
     void SetTabType(TABTYPE type);

--- a/src/valuedlg.h
+++ b/src/valuedlg.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QDialog>
+#include <QJsonValue>
+#include "qjsonutils.h"
 class QNetworkReply;
 class QSettings;
 class QWebEngineView;
@@ -16,22 +18,20 @@ class ValueDlg : public QDialog
 public:
     explicit ValueDlg(QWidget *parent = 0);
     ~ValueDlg();
-    void SetText(QString value, bool sqlHighlight);
-    void SetQuery(QString queryXML);
+    void SetContent(QString id, QString key, QJsonValue value);
 
     static void WriteSettings(QSettings& settings);
     static void ReadSettings(QSettings& settings);
 
-    QString m_id;
-    QString m_key;
-
 protected:
+    void UpdateValueBox();
     void reject() override;
 
 private slots:
     void on_visualizeButton_clicked();
     void on_wrapTextCheck_clicked();
     void on_prevButton_clicked();
+    void on_notationComboBox_currentIndexChanged(const QString& newValue);
     void on_nextButton_clicked();
     void on_uploadFinished(QNetworkReply*);
     void on_loadFinished(bool);
@@ -43,7 +43,6 @@ signals:
     void prev();
 
 private:
-    QString Process(QString in);
     QUrl GetUploadURL();
     QUrl GetVisualizeURL(QNetworkReply * const reply);
     void UploadQuery();
@@ -51,7 +50,10 @@ private:
     void SetWrapping(const bool wrapText);
 
     Ui::ValueDlg *ui;
-    QString m_queryXML;
+    QString m_id;
+    QString m_key;
+    QString m_queryPlan;
+    QJsonValue m_value;
     bool m_visualizationServiceEnable;
     QString m_visualizationServiceURL;
     QWebEngineView *m_view;
@@ -60,4 +62,5 @@ private:
     static QByteArray sm_savedGeometry;
     static qreal sm_savedFontPointSize;
     static bool sm_savedWrapText;
+    static QJsonUtils::Notation sm_notation;
 };

--- a/src/valuedlg.ui
+++ b/src/valuedlg.ui
@@ -61,6 +61,9 @@
       </widget>
      </item>
      <item>
+      <widget class="QComboBox" name="notationComboBox"/>
+     </item>
+     <item>
       <widget class="QToolButton" name="prevButton">
        <property name="font">
         <font>
@@ -156,7 +159,9 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="resources.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>closeButton</sender>


### PR DESCRIPTION
Inspired by Luis' recent addition of YAML and JSON formating for events,
this commit adds a dropdown to the value dialog (the dialog which shows
the event contents) which allows to choose the desired format.

While the global setting was pretty useful, I soon realized that I had
to switch between the different display formats too often, as different
use cases require different formats:
* if I want to execute a Hyper query plan, I first have to change to
  the JSON view
* looking at a logical plan required me to switch either to the YAML or
  flat format
* copy/pasting a SQL query also requires the YAML/flat format

With this change, the used format can be changed directly within the
value dialog. The user's choice is properly persisted, so that the
next time the dialog is opened, the same notation is selected.
The global setting is no longer used for the value dialog but it is
still in use for formatting the event list.