### PR TITLE
Visualize query plans with new log keys

### DIFF
--- a/src/valuedlg.cpp
+++ b/src/valuedlg.cpp
@@ -171,7 +171,7 @@ void ValueDlg::SetContent(QString id, QString key, QJsonValue value)
                 m_queryPlan = queryText;
             }
         }
-        else if (m_key == "query-plan" || m_key == "optimizer-step")
+        else if (m_key.startsWith("query-plan") || m_key == "optimizer-step")
         {
             auto plan = value.toObject()["plan"];
             if (plan.isObject()) {


### PR DESCRIPTION
Make sure we show the 'visualize' button for the new log keys "query-plan-spooling", "query-plan-slow", and "query-plan-canceled".