### PR TITLE
Update appveyor and some source files to Qt 5.11 and MSVC 2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,7 @@ install:
 - set BUILDDIR=build-release
 - set PATH=%QTHOME%\bin;%PATH%
 build_script:
-- dir /b "C:\Program Files (x86)\Microsoft Visual Studio*"
-- dir %QTHOME%
-- dir %QTHOME%\bin\qm*
+- dir %QTHOME%\mkspecs
 - '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64'
 - mkdir %BUILDDIR%
 - cd /d %BUILDDIR%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,10 @@
 install:
-- set QTHOME=C:\Qt\5.7\msvc2013_64
+- set QTHOME=C:\Qt\latest\msvc2013_64
 - set BUILDDIR=build-release
 - set PATH=%QTHOME%\bin;%PATH%
 build_script:
 - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64'
-- dir C:\Qt
-- dir C:\Qt\5.7
+- dir C:\Qt\latest
 - dir %QTHOME%
 - dir %QTHOME%\bin\qm*
 - mkdir %BUILDDIR%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ install:
 build_script:
 - dir C:\Qt
 - dir C:\Qt\5.11
-- dir %QTHOME%
-- dir %QTHOME%\mkspecs\
 - dir "C:\Program Files (x86)\Microsoft Visual Studio*"
 - dir "C:\Program Files (x86)\Microsoft Visual Studio\2017"
+- dir %QTHOME%
+- dir %QTHOME%\mkspecs\
 - '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64'
 - mkdir %BUILDDIR%
 - cd /d %BUILDDIR%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 install:
-- set QTHOME=C:\Qt\latest\msvc2013_64
+- set QTHOME=C:\Qt\latest\msvc2015_64
 - set BUILDDIR=build-release
 - set PATH=%QTHOME%\bin;%PATH%
 build_script:
-- '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64'
-- dir C:\Qt\latest
+- dir /b "C:\Program Files (x86)\Microsoft Visual Studio*"
 - dir %QTHOME%
 - dir %QTHOME%\bin\qm*
+- '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64'
 - mkdir %BUILDDIR%
 - cd /d %BUILDDIR%
-- qmake.exe -spec win32-msvc2013 CONFIG+=x86_64 -Wall ..\src\tableau-log-viewer.pro
+- qmake.exe -spec win32-msvc2015 CONFIG+=x86_64 -Wall ..\src\tableau-log-viewer.pro
 - nmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+image: Visual Studio 2017
 install:
 - set QTHOME=C:\Qt\5.11\msvc2017_64
 - set BUILDDIR=build-release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,6 @@ install:
 - set BUILDDIR=build-release
 - set PATH=%QTHOME%\bin;%PATH%
 build_script:
-- dir C:\Qt
-- dir C:\Qt\5.11
-- dir "C:\Program Files (x86)\Microsoft Visual Studio*"
-- dir "C:\Program Files (x86)\Microsoft Visual Studio\2017"
-- dir %QTHOME%
-- dir %QTHOME%\mkspecs\
 - '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64'
 - mkdir %BUILDDIR%
 - cd /d %BUILDDIR%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,13 @@
 install:
-- set QTHOME=C:\Qt\latest\msvc2015_64
+- set QTHOME=C:\Qt\5.11\msvc2017_64
 - set BUILDDIR=build-release
 - set PATH=%QTHOME%\bin;%PATH%
 build_script:
-- dir %QTHOME%\mkspecs\win32-msvc
-- '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64'
+- dir C:\Qt
+- dir %QTHOME%\mkspecs\
+- dir "C:\Program Files (x86)\Microsoft Visual Studio*"
+- dir "C:\Program Files (x86)\Microsoft Visual Studio\2017"
+- '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64'
 - mkdir %BUILDDIR%
 - cd /d %BUILDDIR%
 - qmake.exe -spec win32-msvc CONFIG+=x86_64 -Wall ..\src\tableau-log-viewer.pro

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ install:
 - set PATH=%QTHOME%\bin;%PATH%
 build_script:
 - dir C:\Qt
+- dir C:\Qt\5.11
+- dir %QTHOME%
 - dir %QTHOME%\mkspecs\
 - dir "C:\Program Files (x86)\Microsoft Visual Studio*"
 - dir "C:\Program Files (x86)\Microsoft Visual Studio\2017"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ install:
 - set PATH=%QTHOME%\bin;%PATH%
 build_script:
 - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64'
+- dir C:\Qt\5.7
+- dir %QTHOME%
+- dir %QTHOME%\bin\qm*
 - mkdir %BUILDDIR%
 - cd /d %BUILDDIR%
 - qmake.exe -spec win32-msvc2013 CONFIG+=x86_64 -Wall ..\src\tableau-log-viewer.pro

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,9 @@ install:
 - set BUILDDIR=build-release
 - set PATH=%QTHOME%\bin;%PATH%
 build_script:
-- dir %QTHOME%\mkspecs
+- dir %QTHOME%\mkspecs\win32-msvc
 - '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64'
 - mkdir %BUILDDIR%
 - cd /d %BUILDDIR%
-- qmake.exe -spec win32-msvc2015 CONFIG+=x86_64 -Wall ..\src\tableau-log-viewer.pro
+- qmake.exe -spec win32-msvc CONFIG+=x86_64 -Wall ..\src\tableau-log-viewer.pro
 - nmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ install:
 - set PATH=%QTHOME%\bin;%PATH%
 build_script:
 - '"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64'
+- dir C:\Qt
 - dir C:\Qt\5.7
 - dir %QTHOME%
 - dir %QTHOME%\bin\qm*

--- a/src/highlightdlg.cpp
+++ b/src/highlightdlg.cpp
@@ -5,6 +5,7 @@
 #include <QDebug>
 #include <QString>
 #include <QKeyEvent>
+#include <QTabBar>
 #include <QTabWidget>
 #include <QWidget>
 #include <QGroupBox>

--- a/src/savefilterdialog.cpp
+++ b/src/savefilterdialog.cpp
@@ -8,6 +8,7 @@
 #include <QFile>
 #include <QJsonDocument>
 #include <QMessageBox>
+#include <QRegularExpression>
 #include <QStandardPaths>
 
 SaveFilterDialog::SaveFilterDialog(QWidget *parent, const HighlightOptions& filters) :


### PR DESCRIPTION
Apparently Qt 5.7 reached EOL and is removed from AppVeyor. Time to jump to latest 5.11. But 5.11 requires MSVC 2017 to use QtWebEngine, and also two include file changes. 

Note: Changing the build environment to MSVC 2017 in the AppVeyor project does not force it to use a new build worker. So it needs to be set in the YML file.