### PR TITLE
Fixed value dialog not redrawing when updated

### DIFF
--- a/src/valuedlg.cpp
+++ b/src/valuedlg.cpp
@@ -212,6 +212,7 @@ void ValueDlg::UpdateValueBox() {
     }
     ui->textEdit->moveCursor(QTextCursor::Start);
     ui->textEdit->ensureCursorVisible();
+    ui->textEdit->repaint();
 }
 
 void ValueDlg::on_nextButton_clicked()


### PR DESCRIPTION
In the dev branch (doesn't seem to repro in the master release, possibly related to Qt update?), the contents of the value dialog text edit control sometimes fail to redraw when they are changed via the prev/next/wordwrap/format controls.