### PR TITLE
Don’t try to format plain strings as JSON objects

### DIFF
--- a/src/qjsonutils.cpp
+++ b/src/qjsonutils.cpp
@@ -26,7 +26,21 @@ namespace
 QString QJsonUtils::Format(const QJsonValue& jsonValue, Notation format, LineFormat lineFormat)
 {
     bool isSingleLine = (lineFormat == LineFormat::SingleLine);
-    if (format == Notation::Flat)
+
+    if (jsonValue.isString())
+    {
+        QString result = jsonValue.toString().trimmed();
+        if (isSingleLine)
+            result = result.replace("\n", " ");
+        return result;
+    }
+    else if (!IsStructured(jsonValue))
+    {
+        QString result;
+        GetJsonLiteral(jsonValue, result);
+        return result;
+    }
+    else if (format == Notation::Flat)
     {
         QVector<QString> stringList;
         GetFlatNotation("", jsonValue, stringList);
@@ -410,4 +424,9 @@ namespace
         }
         return true;
     }
+}
+
+bool QJsonUtils::IsStructured(const QJsonValue &value)
+{
+    return value.isObject() || value.isArray();
 }

--- a/src/qjsonutils.h
+++ b/src/qjsonutils.h
@@ -25,4 +25,6 @@ namespace QJsonUtils
 
     Notation GetNotationFromName(const QString& notationName);
     QString GetNameForNotation(Notation notation);
+
+    bool IsStructured(const QJsonValue& value);
 }

--- a/src/valuedlg.cpp
+++ b/src/valuedlg.cpp
@@ -191,6 +191,9 @@ void ValueDlg::SetContent(QString id, QString key, QJsonValue value)
         ui->visualizeButton->setEnabled(false);
         ui->visualizeLabel->setText("Nothing to visualize");
     }
+
+    ui->notationComboBox->setEnabled(QJsonUtils::IsStructured(value));
+    ui->notationComboBox->repaint();
 }
 
 void ValueDlg::UpdateValueBox() {
@@ -199,6 +202,7 @@ void ValueDlg::UpdateValueBox() {
     int syntaxHighlightLimit = Options::GetInstance().getSyntaxHighlightLimit();
     bool syntaxHighlight = (m_key != "msg" &&
                             !m_key.isEmpty() &&
+                            QJsonUtils::IsStructured(m_value) &&
                             syntaxHighlightLimit &&
                             value.size() <= syntaxHighlightLimit);
     if (syntaxHighlight)
@@ -208,7 +212,13 @@ void ValueDlg::UpdateValueBox() {
     }
     else
     {
-        ui->textEdit->setPlainText(value);
+        // Toggling between "setHtml" and "setPlainText" still winds up formatting
+        // the "plain text" based on the previous HTML contents. The simplest way
+        // to keep it "plain" appears to be to just keep it HTML and omit the styling.
+        // (alternatively, we could explicitly use setTextColor to make it black..
+        //  but that might not play well with themes?)
+        QString htmlText(QString("<body><span>%1</span></body>").arg(value));
+        ui->textEdit->setHtml(htmlText);
     }
     ui->textEdit->moveCursor(QTextCursor::Start);
     ui->textEdit->ensureCursorVisible();


### PR DESCRIPTION
Bypass the Flat/Raw/YAML formatters if the QJsonValue is just a string.