### PR TITLE
Add support to handle newer versions of tableau logs query events

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -922,19 +922,18 @@ void ShowSummary(TreeModel* model, QWidget* parent)
     };
 
     QString beginQueryEventKey = "begin-query";
-    bool foundAQuery = false;
-    for (int i = 0; i < model->rowCount() && !foundAQuery; i++)
+    for (int i = 0; i < model->rowCount(); i++)
     {
         QModelIndex valIndex = model->index(i, COL::Value);
         QString keyString = model->GetEvent(valIndex)["k"].toString();
         if (keyString == "begin-query")
         {
-            foundAQuery = true;
+            break;
         }
         else if (keyString == "begin-protocol.query")
         {
-            foundAQuery = true;
             beginQueryEventKey = "begin-protocol.query";
+            break;
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -921,11 +921,28 @@ void ShowSummary(TreeModel* model, QWidget* parent)
         std::unique_ptr<CounterMap> SubCounters;
     };
 
+    QString beginQueryEventKey = "begin-query";
+    bool foundAQuery = false;
+    for (int i = 0; i < model->rowCount() && !foundAQuery; i++)
+    {
+        QModelIndex valIndex = model->index(i, COL::Value);
+        QString keyString = model->GetEvent(valIndex)["k"].toString();
+        if (keyString == "begin-query")
+        {
+            foundAQuery = true;
+        }
+        else if (keyString == "begin-protocol.query")
+        {
+            foundAQuery = true;
+            beginQueryEventKey = "begin-protocol.query";
+        }
+    }
+
     SummaryCounter counters[] {
         { "Workbook opened", "command-post", "tabui:open-workbook", 0, nullptr },
         { "Query batch", "qp-batch-summary", nullptr, 0, nullptr },
-        { "Query", "begin-query", nullptr, 0, nullptr },
-        { "Query category", "begin-query", "query-category", 0, std::make_unique<CounterMap>() },
+        { "Query", beginQueryEventKey, nullptr, 0, nullptr },
+        { "Query category", beginQueryEventKey, "query-category", 0, std::make_unique<CounterMap>() },
     };
 
     const int rowCount = model->rowCount();

--- a/src/valuedlg.cpp
+++ b/src/valuedlg.cpp
@@ -168,7 +168,9 @@ void ValueDlg::SetContent(QString id, QString key, QJsonValue value)
             m_key == "federate-query" ||
             m_key == "remote-query-planning" ||
             m_key == "begin-query" ||
-            m_key == "end-query")
+            m_key == "begin-protocol.query" ||
+            m_key == "end-query" ||
+            m_key == "end-protocol.query")
         {
             // Assume that queries starting with < have query function trees or logical-query.
             // They normally start with "<?xml ...>", "<sqlproxy>" or "<query-function ...>"


### PR DESCRIPTION
begin-query is changing to begin-protocol.query and end-query to end-protocol.query.

This changes makes Tableau Log Viewer able to handle both the old version and the new version of the names.