### PR TITLE
Time-only for live views; Update NormalizeLogText; Syntax highlight for msg.

### DIFF
--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -44,7 +44,7 @@ void LogTab::InitTreeView(const EventListPtr events)
     m_bar->ShowMessage(QString("%1 events loaded").arg(QString::number(m_treeModel->rowCount())), 3000);
 
     // Display only time if all events occured on the same day
-    bool multipleDays = true;
+    bool multipleDays = false;
     if (events->size() >= 2) {
        QModelIndex idx = ui->treeView->currentIndex();
        auto firstDatetime = m_treeModel->index(0, COL::Time, idx.parent()).data(Qt::UserRole).toDateTime();

--- a/src/logtab.cpp
+++ b/src/logtab.cpp
@@ -652,9 +652,9 @@ void LogTab::ChangePrevIndex()
 
 void NormalizeLogText(QString& logText)
 {
-    std::map<QString, QString> replacements
+    std::vector<std::pair<QString, QString>> replacements
     {
-        {"id: (-)?[\\w+/],", "id: ID"},
+        {"id: (-)?[\\w+/]+,", "id: ID,"},
         {"root: (-)?[\\w+/]+,", "root: ID,"},
         {"sponsor: (-)?[\\w+/]+,", "sponsor: ID,"},
         {"{ e: \\d+, i: \\d+", "{ e: N, i: N"},
@@ -679,13 +679,13 @@ void NormalizeLogText(QString& logText)
         {"federation_\\w{28}", "federation_ID"},
         {"[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}", "GUID"},
         {"#Tableau_[\\w_]+_Connect", "#Tableau_ID_Connect"},
-        {"#Tableau_\\d+_GUID_\\d+", "#Tableau_N_GUID_N"},
         {"#Tableau_\\d+_\\d+", "#Tableau_N_N"},
         {"#Tableau_\\d+_[\\d\\w-]+_", "#Tableau_N_ID_"},
+        {"Tableau_\\d+_GUID_\\d+", "Tableau_N_GUID_N"},
+        {"FQ_Temp_\\d+", "FQ_Temp_N"},
         {"[0-9]{1,2}/[0-9]{1,2}/[0-9]{2,4} [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [AP]M", "TIMESTAMP"},
         {"(\")?tab.domain:\\S+(\")?", "\"tab.endpoint\""},
         {"\"tab.pipe:\\S+\"", "\"tab.endpoint\""},
-        {"i: \\d+; n: \\d+; test: ", "i: N; n: N; test: "},
         {"protocol: [0-9a-f]{12};", "protocol: N;"},
         {"port='\\d+'", "port='N'"},
     };

--- a/src/valuedlg.cpp
+++ b/src/valuedlg.cpp
@@ -209,8 +209,7 @@ void ValueDlg::UpdateValueBox() {
     QString value = QJsonUtils::Format(m_value, sm_notation);
 
     int syntaxHighlightLimit = Options::GetInstance().getSyntaxHighlightLimit();
-    bool syntaxHighlight = (m_key != "msg" &&
-                            !m_key.isEmpty() &&
+    bool syntaxHighlight = (!m_key.isEmpty() &&
                             QJsonUtils::IsStructured(m_value) &&
                             syntaxHighlightLimit &&
                             value.size() <= syntaxHighlightLimit);


### PR DESCRIPTION
- Allow syntax highlight for msg.
Remove syntax highlight restriction on k=msg. It just depends on if the value is structured json value, like a msg with error code.
- Update NormalizeLogText.
Update for new IDs and use vector for ordered list.
- Default live view to show time only.
Default to show time only instead of date and time, when there are less than two initial events, such as in live directory view.
