### PR TITLE
Add options to show/hide ART data and erro code in Value

### DIFF
--- a/src/filtertab.cpp
+++ b/src/filtertab.cpp
@@ -34,7 +34,9 @@ FilterTab::FilterTab(QWidget *parent, QString valueText, QColor backgroundColor)
         {COL::User,       ui->checkBoxUser},
         {COL::Key,        ui->checkBoxKey},
         {COL::Value,      ui->checkBoxValue},
-        {COL::File,       ui->checkBoxFile}
+        {COL::File,       ui->checkBoxFile},
+        {COL::ART,        ui->checkBoxART},
+        {COL::ErrorCode,  ui->checkBoxErrorCode}
     };
 }
 

--- a/src/filtertab.ui
+++ b/src/filtertab.ui
@@ -170,6 +170,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="checkBoxART">
+          <property name="text">
+           <string>ART</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="verticalSpacer_2">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -204,6 +211,13 @@
          <widget class="QCheckBox" name="checkBoxValue">
           <property name="text">
            <string>&amp;Value</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkBoxErrorCode">
+          <property name="text">
+           <string>Error Code</string>
           </property>
          </widget>
         </item>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1332,9 +1332,21 @@ void MainWindow::FindImpl(int offset, bool findHighlight)
                 for (COL col : searchOpt.m_keys)
                 {
                     QModelIndex idx = model->index(i, col);
-                    QString data = (col == COL::Value) ?
-                        model->GetValueFullString(idx, true) :
-                        model->data(idx, Qt::DisplayRole).toString();
+                    QString data;
+                    if (col == COL::Value)
+                    {
+                        data = model->GetValueFullString(idx, true);
+                    }
+                    else if (col == COL::ART || col == COL::ErrorCode)
+                    {
+                        // Some columns only display their data in the tool tip
+                        data = model->data(idx, Qt::ToolTipRole).toString();
+                    }
+                    else
+                    {
+                        // Most columns display their data
+                        data = model->data(idx, Qt::DisplayRole).toString();
+                    }
                     if (searchOpt.HasMatch(data))
                     {
                         tree->setCurrentIndex(idx);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -25,6 +25,8 @@ void Options::ReadSettings()
     m_futureTabsUnderLive = settings.value("enableLiveCapture").toBool();
     m_defaultFilterName = settings.value("defaultHighlightFilter", "None").toString();
     m_captureAllTextFiles = settings.value("liveCaptureAllTextFiles", true).toBool();
+    m_showArtDataInValue = settings.value("showArtDataInValue", false).toBool();
+    m_showErrorCodeInValue = settings.value("showErrorCodeInValue", false).toBool();
     m_syntaxHighlightLimit = settings.value("syntaxHighlightLimit", 15000).toInt();
     m_theme = settings.value("theme", "Native").toString();
     m_notation = settings.value("notation", "YAML").toString();
@@ -54,6 +56,8 @@ void Options::WriteSettings()
     settings.setValue("diffToolPath", m_diffToolPath);
     settings.setValue("enableLiveCapture", m_futureTabsUnderLive);
     settings.setValue("liveCaptureAllTextFiles", m_captureAllTextFiles);
+    settings.setValue("showArtDataInValue", m_showArtDataInValue);
+    settings.setValue("showErrorCodeInValue", m_showErrorCodeInValue);
     settings.setValue("defaultHighlightFilter", m_defaultFilterName);
     settings.setValue("syntaxHighlightLimit", m_syntaxHighlightLimit);
     settings.setValue("theme", m_theme);
@@ -119,6 +123,26 @@ bool Options::getFutureTabsUnderLive() const
 void Options::setFutureTabsUnderLive(const bool futureTabsUnderLive)
 {
     m_futureTabsUnderLive = futureTabsUnderLive;
+}
+
+bool Options::getShowArtDataInValue() const
+{
+    return m_showArtDataInValue;
+}
+
+void Options::setShowArtDataInValue(const bool showArtDataInValue)
+{
+    m_showArtDataInValue = showArtDataInValue;
+}
+
+bool Options::getShowErrorCodeInValue() const
+{
+    return m_showErrorCodeInValue;
+}
+
+void Options::setShowErrorCodeInValue(const bool showErrorCodeInValue)
+{
+    m_showErrorCodeInValue = showErrorCodeInValue;
 }
 
 bool Options::getCaptureAllTextFiles() const

--- a/src/options.h
+++ b/src/options.h
@@ -18,6 +18,8 @@ private:
     QString m_diffToolPath;
     bool m_futureTabsUnderLive;
     bool m_captureAllTextFiles;
+    bool m_showArtDataInValue;
+    bool m_showErrorCodeInValue;
     QString m_defaultFilterName;
     HighlightOptions m_defaultHighlightOpts;
     int m_syntaxHighlightLimit;
@@ -54,6 +56,12 @@ public:
 
     bool getCaptureAllTextFiles() const;
     void setCaptureAllTextFiles(const bool captureAllTextFiles);
+
+    bool getShowArtDataInValue() const;
+    void setShowArtDataInValue(const bool showArtDataInValue);
+
+    bool getShowErrorCodeInValue() const;
+    void setShowErrorCodeInValue(const bool showErrorCodeInValue);
 
     QString getDefaultFilterName() const;
     void setDefaultFilterName(const QString& defaultFilterName);

--- a/src/optionsdlg.cpp
+++ b/src/optionsdlg.cpp
@@ -46,6 +46,8 @@ void OptionsDlg::WriteSettings()
     options.setDiffToolPath(ui->diffToolPath->text());
     options.setFutureTabsUnderLive(ui->startFutureLiveCapture->isChecked());
     options.setCaptureAllTextFiles(ui->captureAllTextFiles->isChecked());
+    options.setShowArtDataInValue(ui->showArtDataInValue->isChecked());
+    options.setShowErrorCodeInValue(ui->showErrorCodeInValue->isChecked());
     options.setDefaultFilterName(ui->defaultHighlightComboBox->currentText());
     options.setSyntaxHighlightLimit(ui->syntaxHighlightLimitSpinBox->value());
     options.setTheme(ui->themeComboBox->currentText());
@@ -77,6 +79,8 @@ void OptionsDlg::ReadSettings()
     ui->diffToolPath->setText(options.getDiffToolPath());
     ui->startFutureLiveCapture->setChecked(options.getFutureTabsUnderLive());
     ui->captureAllTextFiles->setChecked(options.getCaptureAllTextFiles());
+    ui->showArtDataInValue->setChecked(options.getShowArtDataInValue());
+    ui->showErrorCodeInValue->setChecked(options.getShowErrorCodeInValue());
     ui->syntaxHighlightLimitSpinBox->setValue(options.getSyntaxHighlightLimit());
 
     const auto& themeNames = ThemeUtils::GetThemeNames();

--- a/src/optionsdlg.ui
+++ b/src/optionsdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>502</width>
-    <height>529</height>
+    <height>570</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -196,6 +196,26 @@
           </property>
           <property name="text">
            <string>Include all text files in directory live capture</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="showArtDataInValue">
+          <property name="toolTip">
+           <string>If ART data is available in an event, an &quot;~art&quot; attribute is added and displayed in the value</string>
+          </property>
+          <property name="text">
+           <string>Show ART data as part of value</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="showErrorCodeInValue">
+          <property name="toolTip">
+           <string>If Error Code is available in an event, an &quot;~errorcode&quot; attribute is added and displayed in the value</string>
+          </property>
+          <property name="text">
+           <string>Show Error Code as part of value</string>
           </property>
          </widget>
         </item>

--- a/src/searchopt.cpp
+++ b/src/searchopt.cpp
@@ -42,7 +42,9 @@ static QMap<COL, QString> mapColToString{
     {COL::Session,  "Session"},
     {COL::Site,     "Site"},
     {COL::Key,      "Key"},
-    {COL::Value,    "Value"}
+    {COL::Value,    "Value"},
+    {COL::ART,      "ART"},
+    {COL::ErrorCode,"ErrorCode"}
 };
 
 static QMap<SearchMode, QString> mapModeToString{
@@ -84,7 +86,9 @@ static QMap<QString, COL> mapStringToCol{
     {"Session",  COL::Session},
     {"Site",     COL::Site},
     {"Key",      COL::Key},
-    {"Value",    COL::Value}
+    {"Value",    COL::Value},
+    {"ART",      COL::ART},
+    {"ErrorCode",COL::ErrorCode}
 };
 
 static QMap<QString, SearchMode> mapStringToMode{


### PR DESCRIPTION
Fix for issue #105 

Problem: ART data was added to the value under the "~art" attribute. Many persons complained that ART data is not easy to read and most of the time it just gets in the way to read something else. Since TLV objective is to make logs more readable, having a mechanism to declutter the view is welcome.
(something similar happen with "Error Code" column and "~errorcode" artificial attribute)

The Options dialog now has 2 new options:
![image](https://user-images.githubusercontent.com/1087437/50808123-f62a7600-12b1-11e9-85ac-b3f8c377a233.png)

These options are persisted and, by default, they have a "false" value (=> existing TLV users should see the "~art" text disappear without changing any settings)

By removing the ART data and Error code information from the value another problem emerged: it wouldn't be possible to use them in searches. This is actually caused by the fact that we haven't added the ART and Error Code columns to our find and highlight dialogs. This issue is also fixed:

![image](https://user-images.githubusercontent.com/1087437/50808407-40602700-12b3-11e9-98ec-0db65e1710d6.png)

In that example we create a highlight filter for a very specific error code. I tested that finding and highlighting works independently of the values of the new options.


