### PR TITLE
Do not show string values with extra "v"

### DIFF
--- a/src/filtertab.ui
+++ b/src/filtertab.ui
@@ -172,7 +172,7 @@
         <item>
          <widget class="QCheckBox" name="checkBoxART">
           <property name="text">
-           <string>ART</string>
+           <string>&amp;ART</string>
           </property>
          </widget>
         </item>
@@ -217,7 +217,7 @@
         <item>
          <widget class="QCheckBox" name="checkBoxErrorCode">
           <property name="text">
-           <string>Error Code</string>
+           <string>Err&amp;or Code</string>
           </property>
          </widget>
         </item>

--- a/src/treemodel.cpp
+++ b/src/treemodel.cpp
@@ -628,10 +628,10 @@ QString TreeModel::JsonToString(const QJsonValue& json, const bool isSingleLine)
 
 QJsonValue TreeModel::ConsolidateValueAndActivity(const QJsonObject& eventObject) const
 {
-    bool hasART = eventObject.contains("a");
-    bool hasErrorCode = eventObject.contains("e");
+    bool showART = eventObject.contains("a") && Options::GetInstance().getShowArtDataInValue();
+    bool showErrorCode = eventObject.contains("e") && Options::GetInstance().getShowErrorCodeInValue();
     
-    if (hasART || hasErrorCode) {
+    if (showART || showErrorCode) {
         QJsonObject obj;
 
         if (eventObject.contains("v") && eventObject["v"].type() == QJsonValue::Object)
@@ -639,16 +639,13 @@ QJsonValue TreeModel::ConsolidateValueAndActivity(const QJsonObject& eventObject
         else
             obj["v"]=eventObject["v"]; // Create new object with "v"
 
-        bool showART = Options::GetInstance().getShowArtDataInValue();
-        bool showErrorCode = Options::GetInstance().getShowErrorCodeInValue();
-
-        if (hasART && showART) {
+        if (showART) {
             // Using "~art" key so that it appears at the end, otherwise "a" is likely
             // to be the first (alphabetical order) and steals the screen
             obj["~art"] = eventObject["a"];
         }
 
-        if (hasErrorCode && showErrorCode) {
+        if (showErrorCode) {
             obj["~errorcode"] = eventObject["e"];
         }
 


### PR DESCRIPTION
Minor tweaks:
- If error code or ART data is not shown as part of value, skip adding "v:" for plain string values.
- Shortcut keys in find dialog.