### PR TITLE
FIX: #59 - Opening preferences window in Mac changes UI color

### DIFF
--- a/src/optionsdlg.cpp
+++ b/src/optionsdlg.cpp
@@ -162,7 +162,11 @@ void OptionsDlg::on_serviceEnable_clicked()
 
 void OptionsDlg::on_themeComboBox_currentTextChanged(const QString &themeName)
 {
-    ThemeUtils::SwitchTheme(themeName, this->parentWidget());
+    // Only switch the theme after the dialog window is fully loaded (issue #59)
+    if (this->isVisible())
+    {
+        ThemeUtils::SwitchTheme(themeName, this->parentWidget());
+    }
 }
 
 void OptionsDlg::on_OptionsDlg_accepted()

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -195,24 +195,26 @@ std::unique_ptr<Theme> Theme::ThemeFactory(const QString& themeName, QWidget* wi
 
 void Theme::Activate()
 {
-    // For a strange reason (maybe a bug in Qt?), we have to do this twice
-    // to propagate the style and palette to all the controls. Doing it only once
-    // leaves some controls in the old style.
-    for (int i = 0; i < 2; i++)
+    QString defaultStyle = GetDefaultStyle();
+    QStyle* style = this->m_isFusionStyle ?
+        QStyleFactory::create("Fusion") :
+        QStyleFactory::create(defaultStyle);
+
+    qApp->setStyle(style);
+    qApp->setPalette(*m_palette);
+
+    // setPalette() propagates evenly to all widgets. There are several Qt bugs
+    // related to this issue.
+    // The workaround is to call setPalette explicitly for every widget. (issue #59)
+    for (QWidget *widget : qApp->allWidgets())
+        widget->setPalette(*m_palette);
+
+    if (m_isDark)
     {
-        QString defaultStyle = GetDefaultStyle();
-        QStyle* style = this->m_isFusionStyle ?
-            QStyleFactory::create("Fusion") :
-            QStyleFactory::create(defaultStyle);
-        qApp->setStyle(style);
-        qApp->setPalette(*m_palette);
-        if (m_isDark)
-        {
-            ThemeUtils::SetDarkIconSet();
-        }
-        else
-        {
-            ThemeUtils::SetLightIconSet();
-        }
+        ThemeUtils::SetDarkIconSet();
+    }
+    else
+    {
+        ThemeUtils::SetLightIconSet();
     }
 }


### PR DESCRIPTION
Creating a new PR since the last one got blocked by Salesforce CLA requerimests.
------------------------------

The setPalette() function called during the theme activation does not propagate as expected, resulting in some components without the correct palette scheme. As reported in the issue #59 

Several setPalette() related bugs are currently tracked but without a Qt development fix.
[https://bugreports.qt.io/browse/QTBUG-86501?jql=text%20~%20%22QApplication%20setPalette%22](https://bugreports.qt.io/browse/QTBUG-86501?jql=text%20~%20%22QApplication%20setPalette%22)

A workaround is to call the method for every widget in the application when setting a new theme.

```
for (QWidget *widget : qApp->allWidgets())
        widget->setPalette(*m_palette);
```

It may be expensive, but it is a little better than calling `QApplication::setPalette()` and `QApplication::setStyle()` multiple times.

Additional changes in the `src/optionsdlg.cpp` were made to prevent a theme from being set for every element in the theme dropdown during the options window's initialization.